### PR TITLE
provide docker-compose file with extensive configurability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,82 @@
+#######################
+# Github packages configuration
+#######################
+
+# Github credentials for accessing Github packages
+# TOKEN has to have read:packages permissions
+GITHUB_USER=github_username_here
+GITHUB_TOKEN=ghp_ABCDE123456789
+
+#######################
+# Service configuration
+#######################
+
+### BIND_ADDRESS
+### optional
+### which host address the service should bind to, as expected by docker
+### can be either a portnumber or bind_address:portnumber
+#BIND_ADDRESS=127.0.0.1:8080
+
+#######################
+# Mongo configuration
+#######################
+
+### MONGO_HOST
+### optional
+### hostname to mongo
+#MONGO_HOST=mongo
+
+### MONGO_ROOT_USER
+### optional
+### root user name
+#MONGO_ROOT_USER=mongoadmin
+
+### MONGO_ROOT_PASSWORD
+### required
+### root user password
+MONGO_ROOT_PASSWORD=___CHANGEME___
+
+### MONGO_USER
+### optional
+### mongo user name
+#MONGO_USER=agriroutermiddleware
+
+### MONGO_PASSWORD
+### required
+### mongo user password
+MONGO_PASSWORD=___CHANGEME___
+
+### MONGO_DATABASE
+### optional
+### mongo database name
+#MONGO_DATABASE=agriroutermiddleware
+
+
+#######################
+# MySQL configuration
+#######################
+
+### MYSQL_HOST
+### optional
+### hostname to mysql
+#MYSQL_HOST=mysql
+
+### MYSQL_ROOT_PASSWORD
+### required
+### root user password
+MYSQL_ROOT_PASSWORD=___CHANGEME___
+
+### MYSQL_DATABASE
+### optional
+### mysql database name
+#MYSQL_DATABASE=agriroutermiddleware
+
+### MYSQL_USER
+### optional
+### mysql user name
+#MYSQL_USER=agriroutermiddleware
+
+### MYSQL_PASSWORD
+### optional
+### mysql user password
+MYSQL_PASSWORD=___CHANGEME___

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ src/main/generated
 
 # LOCAL SETTINGS #
 ci/local-settings.xml
+
+# ENV FOR DOCKER-COMPOSE SECRETS #
+.env

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -52,3 +52,25 @@ Creating the docker image is straight-forward.
 * Build and install all the dependencies via `mvn clean install`.
 * Run `spring-boot:build-image` to create the docker image within the module `agrirouter-middleware-application`.
 * Run `docker run -it -p8080:8080 agrirouter-middleware-application:1.0-SNAPSHOT` to run the container locally.
+
+### Running the whole stack using docker-compose
+
+You can run the whole required stack, including Mongo and MariaDB, using docker-compose.
+
+* copy `.env.example` to `.env` (or run `./prepare-env.sh`, which sets secure passwords)
+* edit `.env`:
+  * set `GITHUB_USER` and `GITHUB_TOKEN` to credentials from Github, the token only needs `read:packages` rights
+  * set all fields marked as "required" (not needed if `prepare-env` has been used)
+* run (one of) the following commands:
+  * `docker-compose build`: builds the agrirouter-middleware sourcecode and packs it into a docker image
+  * `docker-compose up [-d]`: creates and starts all containers (agrirouter middleware, mongo and mysql) [in detached mode]
+  * `docker-compose stop`: stops the running containers
+  * `docker-compose down [-v]`: removes all containers, but keeps the volumes which hold the data [unless -v is specified]
+  * `docker-compose logs [-f]`: print the accumulated logs from all containers [and follow the output]
+
+After the initializaition of the databases is complete (the middleware container will restart multiple times
+because the database is not available yet) and all containers are up, you can extract the generated tenant credentials from the logs:
+
+```
+docker-compose logs middleware | grep "Generated default" -B 2 -A 8
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM maven:3.8-openjdk-17 as build
+WORKDIR /usr/src
+COPY . .
+
+ARG GITHUB_USER
+ARG GITHUB_TOKEN
+
+RUN mvn --batch-mode --update-snapshots --settings m2-settings.xml verify
+
+FROM openjdk:17
+WORKDIR /srv
+COPY --from=build /usr/src/agrirouter-middleware-application/target/agrirouter-middleware.jar .
+
+CMD java -jar /srv/agrirouter-middleware.jar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,61 @@
+version: "3.7"
+services:
+  middleware:
+    build:
+      context: .
+      args:
+        - GITHUB_USER=${GITHUB_USER}
+        - GITHUB_TOKEN=${GITHUB_TOKEN}
+    environment:
+      - MONGODB_HOST=${MONGO_HOST:-mongo}
+      - MONGODB_PASSWORD=${MONGO_PASSWORD}
+      - MONGODB_PORT=27017
+      - MONGODB_SCHEMA=${MONGO_DATABASE:-agriroutermiddleware}
+      - MONGODB_USER=${MONGO_USER:-agriroutermiddleware}
+      - MYSQL_HOST=${MYSQL_HOST:-mysql}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+      - MYSQL_PORT=${MYSQL_PORT:-3306}
+      - MYSQL_SCHEMA=${MYSQL_DATABASE:-agriroutermiddleware}
+      - MYSQL_USER=${MYSQL_USER:-agriroutermiddleware}
+    ports:
+      - "${BIND_ADDRESS:-127.0.0.1:8080}:8080"
+    networks:
+      - frontend
+      - backend
+    restart: unless-stopped
+
+  mongo:
+    image: mongo:5.0
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=${MONGO_ROOT_USER:-mongoadmin}
+      - MONGO_INITDB_ROOT_PASSWORD=${MONGO_ROOT_PASSWORD}
+      - MONGO_INITDB_DATABASE=${MONGO_DATABASE:-agriroutermiddleware}
+      - MONGO_INITDB_USER=${MONGO_USER:-agriroutermiddleware}
+      - MONGO_INITDB_PWD=${MONGO_PASSWORD}
+    volumes:
+      - mongo_data:/data/db
+      - ./mongo-init.sh:/docker-entrypoint-initdb.d/mongo-init.sh
+    networks:
+      - backend
+    restart: unless-stopped
+
+  mysql:
+    image: mariadb:10.7
+    environment:
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+      - MYSQL_DATABASE=${MYSQL_DATABASE:-agriroutermiddleware}
+      - MYSQL_USER=${MYSQL_USER:-agriroutermiddleware}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+    volumes: 
+      - mysql_data:/var/lib/mysql
+    networks:
+      - backend
+    restart: unless-stopped
+
+networks:
+  backend:
+  frontend:
+
+volumes:
+  mongo_data: {}
+  mysql_data: {}

--- a/m2-settings.xml
+++ b/m2-settings.xml
@@ -1,0 +1,44 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <activeProfiles>
+        <activeProfile>github</activeProfile>
+    </activeProfiles>
+
+    <profiles>
+        <profile>
+            <id>github</id>
+            <repositories>
+                <repository>
+                    <id>central</id>
+                    <url>https://repo1.maven.org/maven2</url>
+                </repository>
+                <repository>
+                    <id>dke-data</id>
+                    <name>GitHub DKE-Data Apache Maven Packages</name>
+                    <url>https://maven.pkg.github.com/DKE-Data/*</url>
+                </repository>
+                <repository>
+                    <id>saschadoemer</id>
+                    <name>GitHub Sascha Doemer Apache Maven Packages</name>
+                    <url>https://maven.pkg.github.com/saschadoemer/*</url>
+                </repository>
+            </repositories>
+        </profile>
+    </profiles>
+
+    <servers>
+        <server>
+            <id>dke-data</id>
+            <username>${GITHUB_USER}</username>
+            <password>${GITHUB_TOKEN}</password>
+        </server>
+        <server>
+            <id>saschadoemer</id>
+            <username>${GITHUB_USER}</username>
+            <password>${GITHUB_TOKEN}</password>
+        </server>
+    </servers>
+</settings>

--- a/mongo-init.sh
+++ b/mongo-init.sh
@@ -1,0 +1,14 @@
+set -e
+
+mongo <<EOF
+use $MONGO_INITDB_DATABASE
+
+db.createUser({
+  user: '$MONGO_INITDB_USER',
+  pwd: '$MONGO_INITDB_PWD',
+  roles: [{
+    role: 'readWrite',
+    db: '$MONGO_INITDB_DATABASE'
+  }]
+})
+EOF

--- a/prepare-env.sh
+++ b/prepare-env.sh
@@ -1,0 +1,22 @@
+# THIS SCRIPT COPIES .env.example TO .env, IF IT DOESN'T EXIST YET
+# THEN IT REPLACES ALL PASSWORD PLACEHOLDERS BY NEW, STRONG PASSWORDS
+
+secure_password() {
+  < /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c${1:-16}
+  echo
+}
+
+if [ -f .env ]; then
+    echo Not overwriting exiting .env, still trying to set passwords...
+else
+    cp .env.example .env
+fi
+
+PLACEHOLDER=___CHANGEME___
+
+grep $PLACEHOLDER .env > /dev/null
+while [ $? -eq 0 ]; do
+    echo Generating one new password...
+    sed -i "0,/$PLACEHOLDER/{s/$PLACEHOLDER/$(secure_password)/}" .env
+    grep $PLACEHOLDER .env > /dev/null
+done


### PR DESCRIPTION
Most relevant settings can be set in an `.env` file, with `.env.example` as a template.
Only in the case where one wants to use some external Mongo or MySQL or both, the configuration for the respective container(s) has to be removed from `docker-compose.yml`.

A bash script `prepare-env.sh` is provided for copying the example env file and pre-populating passwords with strong, random passwords.
This script is idempotent: if the target script already exists, it only replaces remaining password placeholders with generated passwords.