### PR TITLE
Allow overriding the favicon

### DIFF
--- a/agrirouter-middleware-application/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/agrirouter-middleware-application/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -24,6 +24,11 @@
       "name": "app.scheduled.status-logging",
       "type": "java.lang.String",
       "description": "The interval for the status logging, has to be a valid CRON expression."
+    },
+    {
+      "name": "app.branding.favicon",
+      "type": "java.lang.String",
+      "description": "An url to a favicon. Can be a relative or an absolute url. Default is the agrirouter middleware icon."
     }
   ]
 }

--- a/agrirouter-middleware-application/src/main/resources/application.yml
+++ b/agrirouter-middleware-application/src/main/resources/application.yml
@@ -39,3 +39,5 @@ app:
     connection-check: "0 */1 * * * *"
     fetching-and-confirming-existing-messages: "0 */5 * * * *"
     status-logging: "0 */1 * * * *"
+  branding:
+    favicon: "/img/favicon.ico"

--- a/agrirouter-middleware-application/src/main/resources/templates/fragments/layout.html
+++ b/agrirouter-middleware-application/src/main/resources/templates/fragments/layout.html
@@ -6,7 +6,7 @@
     <title th:replace="${title}">Layout Title</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <link rel="stylesheet" href="webjars/material-design-lite/1.3.0/material.min.css"/>
-    <link rel="shortcut icon" type="image/png" th:href="@{/img/favicon.ico}"/>
+    <link rel="shortcut icon" type="image/png" th:href="${@environment.getProperty('app.branding.favicon')}"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.blue_grey-light_green.min.css"/>
 </head>


### PR DESCRIPTION
The favicon is a pretty much a static resource, so it is appropriate to allow to override it statically, i.e. via an environment variable.

To override the favicon, set the following environment variable: APP_BRANDING_FAVICON

Not sure if being context-relative does matter here, I could not find any way that this application would be deployed on an application server (e.g. as a WAR), so I *think* ignoring servlet context paths is okay here, but do correct me if it does matter.