### PR TITLE
Do not deactivate parent endpoint in case the VCU is removed.

### DIFF
--- a/agrirouter-middleware-business/src/main/java/de/agrirouter/middleware/business/EndpointService.java
+++ b/agrirouter-middleware-business/src/main/java/de/agrirouter/middleware/business/EndpointService.java
@@ -122,6 +122,7 @@ public class EndpointService {
      *
      * @param agrirouterEndpointId -
      */
+    @Async
     @Transactional
     public void deleteEndpointDataFromTheMiddlewareByAgrirouterId(String agrirouterEndpointId) {
         final var optionalEndpoint = endpointRepository.findByAgrirouterEndpointIdAndIgnoreDeactivated(agrirouterEndpointId);
@@ -348,12 +349,19 @@ public class EndpointService {
     }
 
     /**
-     * Deactivate the endpoint.
+     * Deactivate an endpoint.
      *
-     * @param endpoint -
+     * @param agrirouterEndpointId The ID of the endpoint.
      */
-    public void deactivateEndpoint(Endpoint endpoint) {
-        endpoint.setDeactivated(true);
-        endpointRepository.save(endpoint);
+    @Transactional
+    public void deactivateEndpointByAgrirouterId(String agrirouterEndpointId) {
+        final var optionalEndpoint = endpointRepository.findByAgrirouterEndpointId(agrirouterEndpointId);
+        if (optionalEndpoint.isPresent()) {
+            final var endpoint = optionalEndpoint.get();
+            endpoint.setDeactivated(true);
+            endpointRepository.save(endpoint);
+        } else {
+            LOGGER.warn("Could not find endpoint with agrirouter ID {}.", agrirouterEndpointId);
+        }
     }
 }

--- a/agrirouter-middleware-business/src/main/java/de/agrirouter/middleware/business/VirtualOnboardProcessService.java
+++ b/agrirouter-middleware-business/src/main/java/de/agrirouter/middleware/business/VirtualOnboardProcessService.java
@@ -8,7 +8,6 @@ import de.agrirouter.middleware.business.parameters.VirtualOnboardProcessParamet
 import de.agrirouter.middleware.integration.VirtualOnboardProcessIntegrationService;
 import de.agrirouter.middleware.integration.parameters.VirtualOnboardProcessIntegrationParameters;
 import de.agrirouter.middleware.persistence.EndpointRepository;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 /**
@@ -34,7 +33,6 @@ public class VirtualOnboardProcessService {
      *
      * @param virtualOnboardProcessParameters -
      */
-    @Async
     public void onboard(VirtualOnboardProcessParameters virtualOnboardProcessParameters) {
         final var alreadyExistingEndpoint = endpointRepository.findByExternalEndpointIdAndIgnoreDeactivated(virtualOnboardProcessParameters.getExternalVirtualEndpointId());
         alreadyExistingEndpoint.ifPresent(endpoint -> {

--- a/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/VirtualOffboardProcessIntegrationService.java
+++ b/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/VirtualOffboardProcessIntegrationService.java
@@ -36,7 +36,7 @@ public class VirtualOffboardProcessIntegrationService {
      * @param virtualOffboardProcessIntegrationParameters The parameters for the offboard process.
      */
     public void offboard(VirtualOffboardProcessIntegrationParameters virtualOffboardProcessIntegrationParameters) {
-        final var onboardingResponse = virtualOffboardProcessIntegrationParameters.getEndpoint().asOnboardingResponse();
+        final var onboardingResponse = virtualOffboardProcessIntegrationParameters.parentEndpoint().asOnboardingResponse();
         final var iMqttClient = mqttClientManagementService.get(onboardingResponse);
         if (iMqttClient.isEmpty()) {
             throw new BusinessException(ErrorMessageFactory.couldNotConnectMqttClient(onboardingResponse.getSensorAlternateId()));
@@ -44,7 +44,7 @@ public class VirtualOffboardProcessIntegrationService {
         final var cloudOffboardingService = new CloudOffboardingServiceImpl(iMqttClient.get());
         final var parameters = new CloudOffboardingParameters();
         parameters.setOnboardingResponse(onboardingResponse);
-        parameters.setEndpointIds(virtualOffboardProcessIntegrationParameters.getEndpointIds());
+        parameters.setEndpointIds(virtualOffboardProcessIntegrationParameters.virtualEndpointIds());
         final var messageId = cloudOffboardingService.send(parameters);
 
         LOGGER.debug("Saving message with ID '{}'  waiting for ACK.", messageId);

--- a/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/VirtualOnboardProcessIntegrationService.java
+++ b/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/VirtualOnboardProcessIntegrationService.java
@@ -12,6 +12,7 @@ import de.agrirouter.middleware.integration.mqtt.MqttClientManagementService;
 import de.agrirouter.middleware.integration.parameters.VirtualOnboardProcessIntegrationParameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -42,6 +43,7 @@ public class VirtualOnboardProcessIntegrationService {
      *
      * @param virtualOnboardProcessIntegrationParameters The parameters for the onboard process.
      */
+    @Async
     public void onboard(VirtualOnboardProcessIntegrationParameters virtualOnboardProcessIntegrationParameters) {
         final var onboardingResponse = virtualOnboardProcessIntegrationParameters.getEndpoint().asOnboardingResponse();
         final var iMqttClient = mqttClientManagementService.get(onboardingResponse);

--- a/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/parameters/VirtualOffboardProcessIntegrationParameters.java
+++ b/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/parameters/VirtualOffboardProcessIntegrationParameters.java
@@ -1,28 +1,14 @@
 package de.agrirouter.middleware.integration.parameters;
 
 import de.agrirouter.middleware.domain.Endpoint;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
 
 import java.util.List;
 
 /**
  * Parameters for the offboard process of a virtual endpoint.
+ *
+ * @param parentEndpoint     The parent endpoint.
+ * @param virtualEndpointIds The endpoint IDs of the virtual endpoints.
  */
-@Getter
-@Setter
-@ToString
-public class VirtualOffboardProcessIntegrationParameters {
-
-    /**
-     * The endpoint.
-     */
-    private Endpoint endpoint;
-
-    /**
-     * The IDs of the endpoints.
-     */
-    private List<String> endpointIds;
-
+public record VirtualOffboardProcessIntegrationParameters(Endpoint parentEndpoint, List<String> virtualEndpointIds) {
 }


### PR DESCRIPTION
Fix level of @Async to avoid exception swallows.
Do not deactivate parent endpoint in case the VCU is removed.