### PR TITLE
Implement actuator external credentials configuration

### DIFF
--- a/FUNCTIONAL_DOCUMENTATION.adoc
+++ b/FUNCTIONAL_DOCUMENTATION.adoc
@@ -20,6 +20,17 @@ During the first startup of the middleware, a default tenant is generated and pr
 You have to store the credentials at a safe place to authenticate again.
 ====
 
+=== External credentials for the actuator endpoints
+
+If you do not want to use the generated credentials for the actuator endpoints, you can define your own credentials.
+You need to activate the profile `actuator-credentials` and set the following environment variables:
+
+|===
+|Name |Description
+|`ACTUATOR_TENANT_ID` | The ID of the tenant to use for the actuator endpoints.
+|`ACTUATOR_TENANT_TOKEN` | The access token of the tenant to use for the actuator endpoints.
+|===
+
 === How to integrate the middleware in your project?
 
 If you have a running instance, the integration is quite easy.

--- a/agrirouter-middleware-application/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/agrirouter-middleware-application/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -114,6 +114,16 @@
       "name": "app.scheduled.random-delay-minutes",
       "type": "java.lang.String",
       "description": "The random delay that will be added to the CRON."
+    },
+    {
+      "name": "app.actuator.tenant-id",
+      "type": "java.lang.String",
+      "description": "The tenant id for the actuator."
+    },
+    {
+      "name": "app.actuator.access-token",
+      "type": "java.lang.String",
+      "description": "The access token for the actuator."
     }
   ]
 }

--- a/agrirouter-middleware-application/src/main/resources/application-actuator-credentials.yml
+++ b/agrirouter-middleware-application/src/main/resources/application-actuator-credentials.yml
@@ -1,0 +1,4 @@
+app:
+  actuator:
+    tenant-id: ${ACTUATOR_TENANT_ID}
+    access-token: ${ACTUATOR_ACCESS_TOKEN}

--- a/agrirouter-middleware-application/src/main/resources/application.yml
+++ b/agrirouter-middleware-application/src/main/resources/application.yml
@@ -3,6 +3,7 @@ spring:
     url: jdbc:mariadb://${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_SCHEMA}?useUnicode=true&characterEncoding=UTF-8${MYSQL_ADDITIONAL_OPTIONS}
     username: ${MYSQL_USER}
     password: ${MYSQL_PASSWORD}
+
   data:
     mongodb:
       host: ${MONGODB_HOST}
@@ -10,6 +11,7 @@ spring:
       database: ${MONGODB_SCHEMA}
       username: ${MONGODB_USER}
       password: ${MONGODB_PASSWORD}
+
   jpa:
     hibernate:
       ddl-auto: validate


### PR DESCRIPTION
Added configuration for external credentials for the actuator in TenantService.java. This allows users to set their own credentials to use the actuator endpoints instead of the generated ones. Updates have also been made to the application.yml and the additional spring configuration metadata, plus the creation of the application-actuator-credentials.yml file to handle these configurations. Instructions on how to use the external credentials have been added to the functional documentation.

Closes #338 