### PR TITLE
Deactivate MQTT clients when endpoints are deactivated.

### DIFF
--- a/agrirouter-middleware-business/src/main/java/de/agrirouter/middleware/business/EndpointService.java
+++ b/agrirouter-middleware-business/src/main/java/de/agrirouter/middleware/business/EndpointService.java
@@ -339,9 +339,11 @@ public class EndpointService {
             log.debug("Deactivate the endpoint to avoid race conditions.");
             endpoint.setDeactivated(true);
             endpointRepository.save(endpoint);
+            mqttClientManagementService.disconnect(endpoint);
             endpoint.getConnectedVirtualEndpoints().forEach(vcu -> {
                 vcu.setDeactivated(true);
                 endpointRepository.save(vcu);
+                mqttClientManagementService.disconnect(vcu);
             });
             if (EndpointType.NON_VIRTUAL.equals(endpoint.getEndpointType())) {
                 final var optionalApplication = applicationRepository.findByEndpointsContains(endpoint);


### PR DESCRIPTION
This change ensures that the MQTT clients are properly disconnected when endpoints and their associated virtual endpoints are deactivated. This helps prevent race conditions and ensures the system state is consistent. This adjustment improves reliability and stability in endpoint handling.