### PR TITLE
Add last known healthy status tracking for endpoints

### DIFF
--- a/agrirouter-middleware-controller/src/main/java/de/agrirouter/middleware/controller/dto/response/DetailedEndpointHealthStatusResponse.java
+++ b/agrirouter-middleware-controller/src/main/java/de/agrirouter/middleware/controller/dto/response/DetailedEndpointHealthStatusResponse.java
@@ -6,6 +6,8 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.Value;
 
+import java.time.Instant;
+
 /**
  * Response class for better API design.
  */
@@ -22,5 +24,11 @@ public class DetailedEndpointHealthStatusResponse extends Response {
      */
     @Schema(description = "The status for a single endpoint, could be either a HTTP 200, if the endpoint is connected, a HTTP 503 if the endpoints has some problems or a HTTP 404 otherwise.")
     HealthStatus healthStatus;
+
+    /**
+     * The last known healthy status for the endpoint.
+     */
+    @Schema(description = "The last known healthy status for the endpoint, could be the same as the current status or a previous one.")
+    Instant lastKnownHealthyStatus;
 
 }

--- a/agrirouter-middleware-controller/src/main/java/de/agrirouter/middleware/controller/secured/EndpointController.java
+++ b/agrirouter-middleware-controller/src/main/java/de/agrirouter/middleware/controller/secured/EndpointController.java
@@ -620,15 +620,15 @@ public class EndpointController implements SecuredApiController {
         if (agrirouterStatusIntegrationService.isOperational()) {
             try {
                 var healthStatus = endpointService.determineHealthStatus(externalEndpointId);
-                return switch (healthStatus) {
+                return switch (healthStatus.getHealthStatus()) {
                     case HEALTHY ->
-                            () -> ResponseEntity.status(HttpStatus.OK).body(new DetailedEndpointHealthStatusResponse(healthStatus));
+                            () -> ResponseEntity.status(HttpStatus.OK).body(new DetailedEndpointHealthStatusResponse(healthStatus.getHealthStatus(), healthStatus.getLastKnownHealthyStatus()));
                     case PENDING ->
-                            () -> ResponseEntity.status(HttpStatus.PROCESSING).body(new DetailedEndpointHealthStatusResponse(healthStatus));
+                            () -> ResponseEntity.status(HttpStatus.PROCESSING).body(new DetailedEndpointHealthStatusResponse(healthStatus.getHealthStatus(), healthStatus.getLastKnownHealthyStatus()));
                     case UNHEALTHY ->
-                            () -> ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(new DetailedEndpointHealthStatusResponse(healthStatus));
+                            () -> ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).body(new DetailedEndpointHealthStatusResponse(healthStatus.getHealthStatus(), healthStatus.getLastKnownHealthyStatus()));
                     case UNKNOWN ->
-                            () -> ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new DetailedEndpointHealthStatusResponse(healthStatus));
+                            () -> ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new DetailedEndpointHealthStatusResponse(healthStatus.getHealthStatus(), healthStatus.getLastKnownHealthyStatus()));
                 };
             } catch (BusinessException e) {
                 if (e.getErrorMessage().getKey().equals(ErrorKey.ENDPOINT_NOT_FOUND)) {

--- a/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/mqtt/health/HealthStatusIntegrationService.java
+++ b/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/mqtt/health/HealthStatusIntegrationService.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.eclipse.paho.client.mqttv3.IMqttClient;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
 import java.util.Optional;
 
 /**
@@ -27,6 +28,7 @@ public class HealthStatusIntegrationService {
     private final HealthStatusMessages healthStatusMessages;
     private final PingService pingService;
     private final MessageWaitingForAcknowledgementService messageWaitingForAcknowledgementService;
+    private final LastKnownHealthyMessages lastKnownHealthyMessages;
 
     /**
      * Publish a health status message to the internal topic.
@@ -99,6 +101,7 @@ public class HealthStatusIntegrationService {
         if (healthStatusMessage != null) {
             healthStatusMessage.setHealthStatus(HealthStatus.HEALTHY);
             healthStatusMessages.put(healthStatusMessage);
+            lastKnownHealthyMessages.put(agrirouterEndpointId);
         }
     }
 
@@ -113,5 +116,15 @@ public class HealthStatusIntegrationService {
             healthStatusMessage.setHealthStatus(HealthStatus.UNHEALTHY);
             healthStatusMessages.put(healthStatusMessage);
         }
+    }
+
+    /**
+     * Get the last known healthy status for the given agrirouter endpoint ID.
+     *
+     * @param agrirouterEndpointId The endpoint ID.
+     * @return The last known healthy status.
+     */
+    public Optional<Instant> getLastKnownHealthyStatus(String agrirouterEndpointId) {
+        return lastKnownHealthyMessages.get(agrirouterEndpointId);
     }
 }

--- a/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/mqtt/health/HealthStatusWithLastKnownHealthyStatus.java
+++ b/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/mqtt/health/HealthStatusWithLastKnownHealthyStatus.java
@@ -1,0 +1,22 @@
+package de.agrirouter.middleware.integration.mqtt.health;
+
+import lombok.Value;
+
+import java.time.Instant;
+
+/**
+ * Container for the health status messages.
+ */
+@Value
+public class HealthStatusWithLastKnownHealthyStatus {
+
+    /**
+     * The status for a single endpoint.
+     */
+    HealthStatus healthStatus;
+
+    /**
+     * The last known healthy status for the endpoint.
+     */
+    Instant lastKnownHealthyStatus;
+}

--- a/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/mqtt/health/LastKnownHealthyMessages.java
+++ b/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/mqtt/health/LastKnownHealthyMessages.java
@@ -1,0 +1,42 @@
+package de.agrirouter.middleware.integration.mqtt.health;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Container for the last known healthy status messages.
+ */
+@Slf4j
+@Component
+public class LastKnownHealthyMessages {
+
+    private final Map<String, Instant> lastKnownHealthyStatus = new HashMap<>();
+
+    /**
+     * Get the last known healthy status for the given endpoint ID.
+     *
+     * @param agrirouterEndpointId The endpoint ID.
+     */
+    public void put(String agrirouterEndpointId) {
+        lastKnownHealthyStatus.put(agrirouterEndpointId, Instant.now());
+    }
+
+    /**
+     * Remove the last known healthy status for the given endpoint ID.
+     *
+     * @param agrirouterEndpointId The endpoint ID.
+     * @return The last known healthy status.
+     */
+    public Optional<Instant> get(String agrirouterEndpointId) {
+        var instant = lastKnownHealthyStatus.get(agrirouterEndpointId);
+        if (instant == null) {
+            log.warn("No last known healthy status found for endpoint ID {}.", agrirouterEndpointId);
+        }
+        return Optional.ofNullable(instant);
+    }
+}


### PR DESCRIPTION
Introduced classes and logic to maintain and retrieve the last known healthy status of endpoints. The `HealthStatusWithLastKnownHealthyStatus` class now encapsulates both the current health status and the last known healthy timestamp, improving the monitoring of endpoint health.