### PR TITLE
Change log level to trace for request duration logging

### DIFF
--- a/agrirouter-middleware-controller/src/main/java/de/agrirouter/middleware/controller/filter/RequestTimeFilter.java
+++ b/agrirouter-middleware-controller/src/main/java/de/agrirouter/middleware/controller/filter/RequestTimeFilter.java
@@ -61,7 +61,7 @@ public class RequestTimeFilter implements Filter {
             filterChain.doFilter(servletRequest, servletResponse);
         } finally {
             var end = Instant.now();
-            log.info("The request to '{}' took {} ms", servletRequest.getServletContext().getContextPath(), end.toEpochMilli() - start.toEpochMilli());
+            log.trace("The request to '{}' took {} ms", servletRequest.getServletContext().getContextPath(), end.toEpochMilli() - start.toEpochMilli());
         }
     }
 }


### PR DESCRIPTION
This modification updates the log level from info to trace for logging the time taken by requests. This is intended to reduce the verbosity of logs, focusing info-level logs on more critical events.