### PR TITLE
Change log level from info to debug for MQTT statistics

### DIFF
--- a/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/mqtt/MqttStatistics.java
+++ b/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/mqtt/MqttStatistics.java
@@ -127,6 +127,6 @@ public class MqttStatistics {
 
     @Scheduled(cron = "${app.scheduled.log-mqtt-statistics}")
     public void log() {
-        log.info("{}", this);
+        log.debug("{}", this);
     }
 }


### PR DESCRIPTION
The log method within MqttStatistics now logs at the debug level instead of info. This change aims to reduce the verbosity of the logs, reserving detailed statistics data for debugging purposes rather than regular operation logs.