### PR TITLE
Lower logging level for tenant service messages

### DIFF
--- a/agrirouter-middleware-api/pom.xml
+++ b/agrirouter-middleware-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>9.0.0-RC</version>
+        <version>9.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-application/pom.xml
+++ b/agrirouter-middleware-application/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>9.0.0-RC</version>
+        <version>9.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-business/pom.xml
+++ b/agrirouter-middleware-business/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>9.0.0-RC</version>
+        <version>9.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-business/src/main/java/de/agrirouter/middleware/business/TenantService.java
+++ b/agrirouter-middleware-business/src/main/java/de/agrirouter/middleware/business/TenantService.java
@@ -158,10 +158,10 @@ public class TenantService implements UserDetailsService {
                 externalActuatorTenant.setMonitoringAccess(true);
                 return new TenantPrincipal(externalActuatorTenant);
             } else {
-                log.info("This was not the external actuator tenant ID. Using the generated tenant information instead.");
+                log.trace("This was not the external actuator tenant ID. Using the generated tenant information instead.");
             }
         } else {
-            log.info("External actuator tenant is not configured. If you want to use the actuator, please configure the tenant ID and access token and use the defined profile.");
+            log.trace("External actuator tenant is not configured. If you want to use the actuator, please configure the tenant ID and access token and use the defined profile.");
         }
         final var optionalTenant = tenantRepository.findTenantByTenantId(tenantId);
         if (optionalTenant.isEmpty()) {

--- a/agrirouter-middleware-controller/pom.xml
+++ b/agrirouter-middleware-controller/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>9.0.0-RC</version>
+        <version>9.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-domain/pom.xml
+++ b/agrirouter-middleware-domain/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>9.0.0-RC</version>
+        <version>9.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-efdi/pom.xml
+++ b/agrirouter-middleware-efdi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>9.0.0-RC</version>
+        <version>9.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-integration/pom.xml
+++ b/agrirouter-middleware-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>9.0.0-RC</version>
+        <version>9.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-isoxml/pom.xml
+++ b/agrirouter-middleware-isoxml/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>9.0.0-RC</version>
+        <version>9.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-persistence/pom.xml
+++ b/agrirouter-middleware-persistence/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>9.0.0-RC</version>
+        <version>9.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>de.agrirouter.middleware</groupId>
     <artifactId>agrirouter-middleware</artifactId>
-    <version>9.0.0-RC</version>
+    <version>9.0.0</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
Changed log level from info to trace for specific external actuator tenant ID checks. This reduces log noise when these conditions are not met.