### PR TITLE
Fix usage of same device in multiple instances

### DIFF
--- a/agrirouter-middleware-business/src/main/java/de/agrirouter/middleware/business/DeviceDescriptionService.java
+++ b/agrirouter-middleware-business/src/main/java/de/agrirouter/middleware/business/DeviceDescriptionService.java
@@ -153,7 +153,7 @@ public class DeviceDescriptionService {
                         if (StringUtils.isBlank(d.getDeviceSerialNumber())) {
                             log.warn("The device serial number is empty, this could lead to problems with the identification of the machines.");
                         }
-                        final var optionalDevice = deviceRepository.findByClientName_ManufacturerCodeAndSerialNumber(cn.getManufacturerCode(), d.getDeviceSerialNumber());
+                        final var optionalDevice = deviceRepository.findByClientName_ManufacturerCodeAndSerialNumberAndExternalEndpointId(cn.getManufacturerCode(), d.getDeviceSerialNumber(), endpoint.getExternalEndpointId());
                         optionalDevice.ifPresentOrElse(device -> {
                             log.debug("The device has been found, using the already existing device.");
                             if (StringUtils.isBlank(device.getInternalDeviceId())) {

--- a/agrirouter-middleware-persistence/src/main/java/de/agrirouter/middleware/persistence/DeviceRepository.java
+++ b/agrirouter-middleware-persistence/src/main/java/de/agrirouter/middleware/persistence/DeviceRepository.java
@@ -16,11 +16,12 @@ public interface DeviceRepository extends MongoRepository<Device, String> {
     /**
      * Find an existing machine.
      *
-     * @param manufacturerCode -
-     * @param serialNumber     -
+     * @param manufacturerCode   -
+     * @param serialNumber       -
+     * @param externalEndpointId -
      * @return -
      */
-    Optional<Device> findByClientName_ManufacturerCodeAndSerialNumber(int manufacturerCode, String serialNumber);
+    Optional<Device> findByClientName_ManufacturerCodeAndSerialNumberAndExternalEndpointId(int manufacturerCode, String serialNumber, String externalEndpointId);
 
     /**
      * Find all devices for the given internal endpoint id.


### PR DESCRIPTION
Until now, a device was searched for without checking for `externalEndpointId`. This means that the processing chain no longer works as desired if the same device was already known once within the agrirouter-middleware 