### PR TITLE
Feature/adapt wait time for agrirouter responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ message-cache
 
 # HTTP CLIENT PRIVATE ENVIRONMENT VARIABLES
 *.env.json
+
+# MAC_OS #
+.DS_Store

--- a/agrirouter-middleware-application/src/main/resources/application.yml
+++ b/agrirouter-middleware-application/src/main/resources/application.yml
@@ -78,7 +78,6 @@ app:
     random-delay-minutes: 240
     empty-message-cache: "0 */30 * * * *"
     message-waiting-for-ack-removal: "0 0 0 * * *"
-    statuspage-check-interval: "*/30 * * * * *"
     log-mqtt-statistics: "*/30 * * * * *"
   branding:
     favicon: "/img/favicon.ico"

--- a/agrirouter-middleware-application/src/main/resources/application.yml
+++ b/agrirouter-middleware-application/src/main/resources/application.yml
@@ -59,12 +59,12 @@ app:
         health:
           response:
             wait:
-              time: 1500
+              time: 300
         response:
           wait:
-            time: 3000
+            time: 1500
           polling:
-            intervall: 100
+            intervall: 50
       options:
         clean-session: false
         keep-alive-interval: 30

--- a/agrirouter-middleware-business/src/main/java/de/agrirouter/middleware/business/EndpointService.java
+++ b/agrirouter-middleware-business/src/main/java/de/agrirouter/middleware/business/EndpointService.java
@@ -563,11 +563,9 @@ public class EndpointService {
 
     public Map<String, Integer> areHealthy(List<String> externalEndpointIds) {
         Map<String, Integer> endpointStatus = new HashMap<>();
-        try {
+        try (var executorService = Executors.newCachedThreadPool()) {
             var callables = new ArrayList<Callable<TaskResult>>();
             externalEndpointIds.forEach(externalEndpointId -> callables.add(createHealthCheckTask(externalEndpointId)));
-            // Looks like the topic is not able to handle more than 2 threads for sending health status messages.
-            var executorService = Executors.newFixedThreadPool(2);
             var futures = executorService.invokeAll(callables);
             waitUntilAllTasksAreDone(futures);
             futures.forEach(future -> {


### PR DESCRIPTION
This pull request includes several modifications aimed at improving the performance and efficiency of the application. The most important changes include adjustments to the configuration settings in `application.yml` and an update to the `EndpointService` class to use a cached thread pool.

Configuration adjustments:

* [`agrirouter-middleware-application/src/main/resources/application.yml`](diffhunk://#diff-68faf9ebfbe2e6b996ecf22af2729a8727374ce8f4e12b979b396f6cf9664009L62-R67): Reduced the health response wait time from 1500ms to 300ms, response wait time from 3000ms to 1500ms, and polling interval from 100ms to 50ms. These changes will likely improve the responsiveness and efficiency of the health checks.
* [`agrirouter-middleware-application/src/main/resources/application.yml`](diffhunk://#diff-68faf9ebfbe2e6b996ecf22af2729a8727374ce8f4e12b979b396f6cf9664009L81): Removed the `statuspage-check-interval` configuration, which might have been deemed unnecessary or redundant.

Codebase update:

* [`agrirouter-middleware-business/src/main/java/de/agrirouter/middleware/business/EndpointService.java`](diffhunk://#diff-75e975d424183b61f194ebf06252f76ffeff80f2a836a92ed7a2dd4d6674697fL566-L570): Updated the `areHealthy` method to use `Executors.newCachedThreadPool()` instead of a fixed thread pool. This change allows for more flexible and efficient handling of concurrent health check tasks.