### PR TITLE
Use explicit type declaration for ExecutorService

### DIFF
--- a/agrirouter-middleware-business/src/main/java/de/agrirouter/middleware/business/EndpointService.java
+++ b/agrirouter-middleware-business/src/main/java/de/agrirouter/middleware/business/EndpointService.java
@@ -563,7 +563,7 @@ public class EndpointService {
 
     public Map<String, Integer> areHealthy(List<String> externalEndpointIds) {
         Map<String, Integer> endpointStatus = new HashMap<>();
-        try (var executorService = Executors.newCachedThreadPool()) {
+        try (ExecutorService executorService = Executors.newCachedThreadPool()) {
             var callables = new ArrayList<Callable<TaskResult>>();
             externalEndpointIds.forEach(externalEndpointId -> callables.add(createHealthCheckTask(externalEndpointId)));
             var futures = executorService.invokeAll(callables);


### PR DESCRIPTION
Replaced the use of `var` with `ExecutorService` for clarity and consistency in the `areHealthy` method. This enhances code readability and aligns with best practices for type declaration in this context.