### PR TITLE
Switch to Amazon Corretto 21 and add Docker build step

### DIFF
--- a/.github/dockerfile
+++ b/.github/dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM amazoncorretto:21-alpine
 
 ADD agrirouter-middleware-application/target/agrirouter-middleware.jar /opt/application/application.jar
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -31,3 +31,10 @@ jobs:
           report_paths: '**/target/surefire-reports/*.xml'
           detailed_summary: true
           include_passed: true
+      - name: Docker Build
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: false
+          file: .github/dockerfile
+          tags: ${{ github.sha }}


### PR DESCRIPTION
Updated the Docker base image to Amazon Corretto 21 for better compatibility and performance. Added a Docker build step in the CI workflow to validate the Dockerfile and ensure images are properly built.