### PR TITLE
Upgrade project version to 10.0.0-RC

### DIFF
--- a/agrirouter-middleware-api/pom.xml
+++ b/agrirouter-middleware-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>9.3.1</version>
+        <version>10.0.0-RC</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-application/pom.xml
+++ b/agrirouter-middleware-application/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>9.3.1</version>
+        <version>10.0.0-RC</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-business/pom.xml
+++ b/agrirouter-middleware-business/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>9.3.1</version>
+        <version>10.0.0-RC</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-controller/pom.xml
+++ b/agrirouter-middleware-controller/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>9.3.1</version>
+        <version>10.0.0-RC</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-domain/pom.xml
+++ b/agrirouter-middleware-domain/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>9.3.1</version>
+        <version>10.0.0-RC</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-efdi/pom.xml
+++ b/agrirouter-middleware-efdi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>9.3.1</version>
+        <version>10.0.0-RC</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-integration/pom.xml
+++ b/agrirouter-middleware-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>9.3.1</version>
+        <version>10.0.0-RC</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-isoxml/pom.xml
+++ b/agrirouter-middleware-isoxml/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>9.3.1</version>
+        <version>10.0.0-RC</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-persistence/pom.xml
+++ b/agrirouter-middleware-persistence/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>9.3.1</version>
+        <version>10.0.0-RC</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>de.agrirouter.middleware</groupId>
     <artifactId>agrirouter-middleware</artifactId>
-    <version>9.3.1</version>
+    <version>10.0.0-RC</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
Updated all module POM files to reference the new parent version `10.0.0-RC`, replacing the previous version `9.3.1`. This prepares the project for the upcoming release candidate.