### PR TITLE
Update version from 10.1.0-RC to 10.1.0 in all modules

### DIFF
--- a/agrirouter-middleware-api/pom.xml
+++ b/agrirouter-middleware-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>10.1.0-RC</version>
+        <version>10.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-application/pom.xml
+++ b/agrirouter-middleware-application/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>10.1.0-RC</version>
+        <version>10.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-business/pom.xml
+++ b/agrirouter-middleware-business/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>10.1.0-RC</version>
+        <version>10.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-controller/pom.xml
+++ b/agrirouter-middleware-controller/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>10.1.0-RC</version>
+        <version>10.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-domain/pom.xml
+++ b/agrirouter-middleware-domain/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>10.1.0-RC</version>
+        <version>10.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-efdi/pom.xml
+++ b/agrirouter-middleware-efdi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>10.1.0-RC</version>
+        <version>10.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-integration/pom.xml
+++ b/agrirouter-middleware-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>10.1.0-RC</version>
+        <version>10.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-isoxml/pom.xml
+++ b/agrirouter-middleware-isoxml/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>10.1.0-RC</version>
+        <version>10.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-persistence/pom.xml
+++ b/agrirouter-middleware-persistence/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>10.1.0-RC</version>
+        <version>10.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>de.agrirouter.middleware</groupId>
     <artifactId>agrirouter-middleware</artifactId>
-    <version>10.1.0-RC</version>
+    <version>10.1.0</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
Promoted the project from the release candidate (RC) version to the stable 10.1.0 version. This applies to the parent POM and all related module POMs, ensuring consistency across the entire build.