### PR TITLE
( ´ ∀ `)ノ～ ♡ | Bugfix/add message cache converter for message cache entries

### DIFF
--- a/agrirouter-middleware-application/src/main/resources/application.yml
+++ b/agrirouter-middleware-application/src/main/resources/application.yml
@@ -88,7 +88,6 @@ app:
     message-cache:
       batch-size: 50
       batch-sleep-time-seconds: 5
-      data-directory: ${MESSAGE_CACHE_DATA_DIRECTORY}
     transient-machine-registration-cache:
       time-to-live-in-seconds: 300
   subscriptions:

--- a/agrirouter-middleware-business/src/main/java/de/agrirouter/middleware/business/cache/messaging/MessageCache.java
+++ b/agrirouter-middleware-business/src/main/java/de/agrirouter/middleware/business/cache/messaging/MessageCache.java
@@ -1,5 +1,9 @@
 package de.agrirouter.middleware.business.cache.messaging;
 
+import com.dke.data.agrirouter.api.enums.ContentMessageType;
+import com.dke.data.agrirouter.api.enums.SystemMessageType;
+import com.dke.data.agrirouter.api.enums.TechnicalMessageType;
+import com.google.protobuf.ByteString;
 import de.agrirouter.middleware.business.events.ResendMessageCacheEntryEvent;
 import de.agrirouter.middleware.domain.documents.MessageCacheEntry;
 import de.agrirouter.middleware.integration.parameters.MessagingIntegrationParameters;
@@ -8,6 +12,7 @@ import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ThreadUtils;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
@@ -61,10 +66,10 @@ public class MessageCache {
                 trace(messageCacheEntry);
                 messageCacheEntryRepository.delete(messageCacheEntry);
                 applicationEventPublisher.publishEvent(new ResendMessageCacheEntryEvent(this, new MessagingIntegrationParameters(messageCacheEntry.getExternalEndpointId(),
-                        messageCacheEntry.getTechnicalMessageType(),
+                        fromStringToTechnicalMessageType(messageCacheEntry.getTechnicalMessageType()),
                         messageCacheEntry.getRecipients(),
                         messageCacheEntry.getFilename(),
-                        messageCacheEntry.getMessage(),
+                        ByteString.copyFromUtf8(messageCacheEntry.getMessage()),
                         messageCacheEntry.getTeamSetContextId())));
             }
             if (page.hasNext()) {
@@ -76,6 +81,18 @@ public class MessageCache {
                 } catch (InterruptedException e) {
                     log.error("There was an error while waiting for the next batch of messages to be sent.", e);
                 }
+            }
+        }
+    }
+
+    private TechnicalMessageType fromStringToTechnicalMessageType(@NotNull String technicalMessageType) {
+        try {
+            return ContentMessageType.valueOf(technicalMessageType);
+        } catch (IllegalArgumentException e) {
+            try {
+                return SystemMessageType.valueOf(technicalMessageType);
+            } catch (IllegalArgumentException e1) {
+                throw new IllegalArgumentException("Could not convert technical message type " + technicalMessageType + " to a string.");
             }
         }
     }
@@ -101,15 +118,33 @@ public class MessageCache {
         log.trace("External endpoint ID: {}", externalEndpointId);
         var messageCacheEntry = new MessageCacheEntry(
                 externalEndpointId,
-                messagingIntegrationParameters.technicalMessageType(),
+                fromTechnicalMessageTypeToString(messagingIntegrationParameters.technicalMessageType()),
                 messagingIntegrationParameters.recipients(),
                 messagingIntegrationParameters.filename(),
-                messagingIntegrationParameters.message(),
+                messagingIntegrationParameters.message().toStringUtf8(),
                 messagingIntegrationParameters.teamSetContextId(),
                 Instant.now(),
                 Instant.now().plus(Duration.ofDays(14))
         );
         messageCacheEntryRepository.save(messageCacheEntry);
+    }
+
+    /**
+     * Convert a string to a technical message type.
+     *
+     * @param technicalMessageType The technical message type.
+     * @return The string representation of the technical message type.
+     */
+    private String fromTechnicalMessageTypeToString(@NotNull TechnicalMessageType technicalMessageType) {
+        if (technicalMessageType instanceof ContentMessageType) {
+            return ((ContentMessageType) technicalMessageType).name();
+        } else {
+            if (technicalMessageType instanceof SystemMessageType) {
+                return ((SystemMessageType) technicalMessageType).name();
+            } else {
+                throw new IllegalArgumentException("Could not convert technical message type " + technicalMessageType + " to a string.");
+            }
+        }
     }
 
 }

--- a/agrirouter-middleware-domain/src/main/java/de/agrirouter/middleware/domain/documents/MessageCacheEntry.java
+++ b/agrirouter-middleware-domain/src/main/java/de/agrirouter/middleware/domain/documents/MessageCacheEntry.java
@@ -57,6 +57,6 @@ public class MessageCacheEntry extends NoSqlBaseEntity {
     /**
      * The date of expiration, two weeks in the future.
      */
-    @Indexed(name = "ttl_index", expireAfterSeconds = 60 * 60 * 24 * 14)
+    @Indexed(name = "ttl_index", expireAfter = "14D")
     private Instant expiredOn;
 }

--- a/agrirouter-middleware-domain/src/main/java/de/agrirouter/middleware/domain/documents/MessageCacheEntry.java
+++ b/agrirouter-middleware-domain/src/main/java/de/agrirouter/middleware/domain/documents/MessageCacheEntry.java
@@ -1,7 +1,5 @@
 package de.agrirouter.middleware.domain.documents;
 
-import com.dke.data.agrirouter.api.enums.TechnicalMessageType;
-import com.google.protobuf.ByteString;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -29,7 +27,7 @@ public class MessageCacheEntry extends NoSqlBaseEntity {
     /**
      * The type of the message.
      */
-    private TechnicalMessageType technicalMessageType;
+    private String technicalMessageType;
 
     /**
      * The recipients.
@@ -44,7 +42,7 @@ public class MessageCacheEntry extends NoSqlBaseEntity {
     /**
      * The message.
      */
-    private ByteString message;
+    private String message;
 
     /**
      * The team set context ID.

--- a/agrirouter-middleware-local/docker-compose.yml
+++ b/agrirouter-middleware-local/docker-compose.yml
@@ -45,7 +45,6 @@ services:
       - MYSQL_PORT=3306
       - MYSQL_SCHEMA=agriroutermiddleware
       - MYSQL_USER=mysqluser
-      - MESSAGE_CACHE_DATA_DIRECTORY=/tmp/.message-cache # This is a temporary solution, please use a PVC for production
       - SPRING_PROFILES_ACTIVE=prod,connect-agrirouter-prod
       - JAVA_OPTS=-Xms1024m -Xmx3276m -Xss10m
       - AGRIROUTER_STATUS_SKIP_CHECK=true


### PR DESCRIPTION
This pull request refactors the handling of `MessageCacheEntry` in the middleware application to simplify data storage and improve type conversion. Key changes include replacing complex types with simpler string representations in the `MessageCacheEntry` class, introducing helper methods for type conversions, and updating related logic in the `MessageCache` class.

### Refactoring of `MessageCacheEntry`:

* Changed the `technicalMessageType` field in `MessageCacheEntry` from `TechnicalMessageType` to `String` for easier storage and retrieval. (`[agrirouter-middleware-domain/src/main/java/de/agrirouter/middleware/domain/documents/MessageCacheEntry.javaL32-R30](diffhunk://#diff-c356d336ade9c17ace3f9102378f6cea8b0006e38f2a58ad55c3ee633a5504dbL32-R30)`)
* Changed the `message` field in `MessageCacheEntry` from `ByteString` to `String` to simplify serialization. (`[agrirouter-middleware-domain/src/main/java/de/agrirouter/middleware/domain/documents/MessageCacheEntry.javaL47-R45](diffhunk://#diff-c356d336ade9c17ace3f9102378f6cea8b0006e38f2a58ad55c3ee633a5504dbL47-R45)`)
* Updated the `@Indexed` annotation for the `expiredOn` field to use a string-based duration format (`"14D"`) instead of a calculated value. (`[agrirouter-middleware-domain/src/main/java/de/agrirouter/middleware/domain/documents/MessageCacheEntry.javaL62-R60](diffhunk://#diff-c356d336ade9c17ace3f9102378f6cea8b0006e38f2a58ad55c3ee633a5504dbL62-R60)`)

### Updates to `MessageCache` logic:

* Replaced direct usage of `TechnicalMessageType` with helper methods `fromStringToTechnicalMessageType` and `fromTechnicalMessageTypeToString` to handle type conversions between `String` and `TechnicalMessageType`. (`[[1]](diffhunk://#diff-ff36ce89265603e0bf370120874b87c10bf7363eb114a6ebc6344ca3c918e788R88-R99)`, `[[2]](diffhunk://#diff-ff36ce89265603e0bf370120874b87c10bf7363eb114a6ebc6344ca3c918e788L104-R149)`)
* Updated the `sendMessages` and `put` methods to use the new string-based representation of `technicalMessageType` and `message`. (`[[1]](diffhunk://#diff-ff36ce89265603e0bf370120874b87c10bf7363eb114a6ebc6344ca3c918e788L64-R72)`, `[[2]](diffhunk://#diff-ff36ce89265603e0bf370120874b87c10bf7363eb114a6ebc6344ca3c918e788L104-R149)`)

### Configuration cleanup:

* Removed the unused `data-directory` property from `application.yml` under `message-cache`. (`[agrirouter-middleware-application/src/main/resources/application.ymlL91](diffhunk://#diff-68faf9ebfbe2e6b996ecf22af2729a8727374ce8f4e12b979b396f6cf9664009L91)`)