### PR TITLE
Feature/additional error messages for ping messages not returned

### DIFF
--- a/agrirouter-middleware-api/pom.xml
+++ b/agrirouter-middleware-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>11.0.0</version>
+        <version>11.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-application/pom.xml
+++ b/agrirouter-middleware-application/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>11.0.0</version>
+        <version>11.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-business/pom.xml
+++ b/agrirouter-middleware-business/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>11.0.0</version>
+        <version>11.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-business/src/main/java/de/agrirouter/middleware/business/EndpointService.java
+++ b/agrirouter-middleware-business/src/main/java/de/agrirouter/middleware/business/EndpointService.java
@@ -470,7 +470,10 @@ public class EndpointService {
         return switch (healthStatusMessage.getHealthStatus()) {
             case ACK -> HttpStatus.OK;
             case ACK_WITH_FAILURE -> HttpStatus.NOT_FOUND;
-            default -> HttpStatus.INTERNAL_SERVER_ERROR;
+            default -> {
+                log.warn("Received an unexpected health status: '{}'. Returning INTERNAL_SERVER_ERROR.", healthStatusMessage.getHealthStatus());
+                yield HttpStatus.INTERNAL_SERVER_ERROR;
+            }
         };
     }
 

--- a/agrirouter-middleware-business/src/main/java/de/agrirouter/middleware/business/EndpointService.java
+++ b/agrirouter-middleware-business/src/main/java/de/agrirouter/middleware/business/EndpointService.java
@@ -194,29 +194,6 @@ public class EndpointService {
         sensorAlternateIds.forEach(removeEndpointDataService::removeData);
     }
 
-
-    /**
-     * Resending the capabilities.
-     *
-     * @param externalEndpointId The internal ID of the endpoint.
-     */
-    @Async
-    public void resendCapabilities(String externalEndpointId) {
-        final var optionalEndpoint = findByExternalEndpointId(externalEndpointId);
-        if (optionalEndpoint.isPresent()) {
-            final var endpoint = optionalEndpoint.get();
-            final var optionalApplication = applicationRepository.findByEndpointsContains(endpoint);
-            if (optionalApplication.isPresent()) {
-                sendCapabilities(optionalApplication.get(), endpoint);
-                businessOperationLogService.log(new EndpointLogInformation(endpoint.getExternalEndpointId(), endpoint.getAgrirouterEndpointId()), "Capabilities were resent.");
-            } else {
-                throw new BusinessException(ErrorMessageFactory.couldNotFindApplication());
-            }
-        } else {
-            log.warn("Tried to resend capabilities for an endpoint with the ID '{}', but it was not found.", externalEndpointId);
-        }
-    }
-
     /**
      * Sending the capabilties for an endpoint.
      *

--- a/agrirouter-middleware-business/src/main/java/de/agrirouter/middleware/business/EndpointService.java
+++ b/agrirouter-middleware-business/src/main/java/de/agrirouter/middleware/business/EndpointService.java
@@ -445,7 +445,7 @@ public class EndpointService {
      */
     public HealthStatusWithLastKnownHealthyStatus determineHealthStatus(String externalEndpointId) {
         final var optionalEndpoint = findByExternalEndpointId(externalEndpointId);
-        var healthStatus = HttpStatus.NOT_FOUND;
+        var healthStatus = HttpStatus.INTERNAL_SERVER_ERROR;
         if (optionalEndpoint.isPresent()) {
             var endpoint = optionalEndpoint.get();
             healthStatusIntegrationService.removeAllPendingHealthStatusMessagesForEndpoint(endpoint.getAgrirouterEndpointId());
@@ -493,8 +493,7 @@ public class EndpointService {
         return switch (healthStatusMessage.getHealthStatus()) {
             case ACK -> HttpStatus.OK;
             case ACK_WITH_FAILURE -> HttpStatus.NOT_FOUND;
-            default ->
-                    throw new IllegalArgumentException("Unknown health status: " + healthStatusMessage.getHealthStatus());
+            default -> HttpStatus.INTERNAL_SERVER_ERROR;
         };
     }
 

--- a/agrirouter-middleware-controller/pom.xml
+++ b/agrirouter-middleware-controller/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>11.0.0</version>
+        <version>11.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-domain/pom.xml
+++ b/agrirouter-middleware-domain/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>11.0.0</version>
+        <version>11.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-efdi/pom.xml
+++ b/agrirouter-middleware-efdi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>11.0.0</version>
+        <version>11.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-integration/pom.xml
+++ b/agrirouter-middleware-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>11.0.0</version>
+        <version>11.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-isoxml/pom.xml
+++ b/agrirouter-middleware-isoxml/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>11.0.0</version>
+        <version>11.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-persistence/pom.xml
+++ b/agrirouter-middleware-persistence/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>11.0.0</version>
+        <version>11.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>de.agrirouter.middleware</groupId>
     <artifactId>agrirouter-middleware</artifactId>
-    <version>11.0.0</version>
+    <version>11.1.0</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
This pull request includes version updates across multiple modules and refactors some methods in the `EndpointService` class to improve error handling and simplify the codebase. The most important changes include updating the parent POM version to `11.1.0` and modifying the handling of health status responses.

### Version Updates:
* Updated the parent POM version from `11.0.0` to `11.1.0` across all module-specific `pom.xml` files (`agrirouter-middleware-api`, `agrirouter-middleware-application`, `agrirouter-middleware-business`, `agrirouter-middleware-controller`, `agrirouter-middleware-domain`, `agrirouter-middleware-efdi`, `agrirouter-middleware-integration`, `agrirouter-middleware-isoxml`, `agrirouter-middleware-persistence`, and the root `pom.xml`). [[1]](diffhunk://#diff-3266ba49ea2fc6d0c016f52b0d0f5a9772a33a084b857cf78fa272e19df9c774L8-R8) [[2]](diffhunk://#diff-cbfad6aba8c743cd3bad4f9de094e37da7159f5053659a40e0ff1210025d7282L8-R8) [[3]](diffhunk://#diff-ec00f17b74d77aa1eafd2dd9f65c2c9c1b6078e2e603f91e776ed13edcc2ee81L8-R8) [[4]](diffhunk://#diff-66015f5c02baa1638a86c70ce6850b82c629d2309a41fe0c970f3dc047aee5fdL8-R8) [[5]](diffhunk://#diff-6fcfb0cbf859323b67928891bcddab33ef01f01ed29f504c6797aeac76d9c8b2L8-R8) [[6]](diffhunk://#diff-a7e6daacfd8bf22e162b86ede37d09ead10281d02e31aae0a63e30137e2c6b64L8-R8) [[7]](diffhunk://#diff-3c1c7139bb71b65e3d49fda6596c4635ddcc0ee56bca1588c472c93b91b5ce82L8-R8) [[8]](diffhunk://#diff-11cacabe5d7385b853ebc02171239cac60f196f430c7f5acb876784f3d1f738dL8-R8) [[9]](diffhunk://#diff-d7280985f01ac6df5a6a07deff0b8f4fb68669300b0eadaa64aa738e276d564eL8-R8) [[10]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L16-R16)

### Code Refactoring:
* Removed the `resendCapabilities` method from `EndpointService`, as it was no longer required.
* Changed the default health status in `determineHealthStatus` from `HttpStatus.NOT_FOUND` to `HttpStatus.INTERNAL_SERVER_ERROR` for better error reporting.
* Updated the `mapAgrirouterResponseToHealthStatus` method to return `HttpStatus.INTERNAL_SERVER_ERROR` instead of throwing an exception for unknown health statuses, improving resilience.