### PR TITLE
( ´ ∀ `)ノ～ ♡ | Bugfix/adapt health checking and use sequential mode

### DIFF
--- a/agrirouter-middleware-api/pom.xml
+++ b/agrirouter-middleware-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>11.1.0</version>
+        <version>11.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-application/pom.xml
+++ b/agrirouter-middleware-application/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>11.1.0</version>
+        <version>11.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-business/pom.xml
+++ b/agrirouter-middleware-business/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>11.1.0</version>
+        <version>11.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-controller/pom.xml
+++ b/agrirouter-middleware-controller/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>11.1.0</version>
+        <version>11.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-domain/pom.xml
+++ b/agrirouter-middleware-domain/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>11.1.0</version>
+        <version>11.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-efdi/pom.xml
+++ b/agrirouter-middleware-efdi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>11.1.0</version>
+        <version>11.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-integration/pom.xml
+++ b/agrirouter-middleware-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>11.1.0</version>
+        <version>11.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-isoxml/pom.xml
+++ b/agrirouter-middleware-isoxml/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>11.1.0</version>
+        <version>11.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-persistence/pom.xml
+++ b/agrirouter-middleware-persistence/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>11.1.0</version>
+        <version>11.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>de.agrirouter.middleware</groupId>
     <artifactId>agrirouter-middleware</artifactId>
-    <version>11.1.0</version>
+    <version>11.2.0</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
This pull request introduces a version upgrade across multiple modules and refactors the `EndpointService` class to simplify the health check logic by removing multithreading and related utilities. The most important changes are grouped into version updates and code refactoring.

### Version Updates:
* Updated the parent project version from `11.1.0` to `11.2.0` in the root `pom.xml` and all module-specific `pom.xml` files, including `agrirouter-middleware-api`, `agrirouter-middleware-application`, `agrirouter-middleware-business`, `agrirouter-middleware-controller`, `agrirouter-middleware-domain`, `agrirouter-middleware-efdi`, `agrirouter-middleware-integration`, `agrirouter-middleware-isoxml`, and `agrirouter-middleware-persistence`. [[1]](diffhunk://#diff-3266ba49ea2fc6d0c016f52b0d0f5a9772a33a084b857cf78fa272e19df9c774L8-R8) [[2]](diffhunk://#diff-cbfad6aba8c743cd3bad4f9de094e37da7159f5053659a40e0ff1210025d7282L8-R8) [[3]](diffhunk://#diff-ec00f17b74d77aa1eafd2dd9f65c2c9c1b6078e2e603f91e776ed13edcc2ee81L8-R8) [[4]](diffhunk://#diff-66015f5c02baa1638a86c70ce6850b82c629d2309a41fe0c970f3dc047aee5fdL8-R8) [[5]](diffhunk://#diff-6fcfb0cbf859323b67928891bcddab33ef01f01ed29f504c6797aeac76d9c8b2L8-R8) [[6]](diffhunk://#diff-a7e6daacfd8bf22e162b86ede37d09ead10281d02e31aae0a63e30137e2c6b64L8-R8) [[7]](diffhunk://#diff-3c1c7139bb71b65e3d49fda6596c4635ddcc0ee56bca1588c472c93b91b5ce82L8-R8) [[8]](diffhunk://#diff-11cacabe5d7385b853ebc02171239cac60f196f430c7f5acb876784f3d1f738dL8-R8) [[9]](diffhunk://#diff-d7280985f01ac6df5a6a07deff0b8f4fb68669300b0eadaa64aa738e276d564eL8-R8) [[10]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L16-R16)

### Code Refactoring in `EndpointService`:
* Removed the fixed thread pool implementation for health checks, including the `fixedThreadPoolSize` property, `TaskResult` record, `waitUntilAllTasksAreDone` method, and `createHealthCheckTask` method. The health check logic now sequentially determines the health status for each endpoint. [[1]](diffhunk://#diff-75e975d424183b61f194ebf06252f76ffeff80f2a836a92ed7a2dd4d6674697fL78-L80) [[2]](diffhunk://#diff-75e975d424183b61f194ebf06252f76ffeff80f2a836a92ed7a2dd4d6674697fR559-L577) [[3]](diffhunk://#diff-75e975d424183b61f194ebf06252f76ffeff80f2a836a92ed7a2dd4d6674697fL593-L623)
* Cleaned up imports by removing unused `java.util.concurrent.*` classes and retaining only the necessary ones.