### PR TITLE
( ´ ∀ `)ノ～ ♡ | Feature/adapt naming of prometheus metrics for messages arrived

### DIFF
--- a/agrirouter-middleware-api/pom.xml
+++ b/agrirouter-middleware-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>11.2.0</version>
+        <version>11.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-application/pom.xml
+++ b/agrirouter-middleware-application/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>11.2.0</version>
+        <version>11.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-business/pom.xml
+++ b/agrirouter-middleware-business/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>11.2.0</version>
+        <version>11.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-controller/pom.xml
+++ b/agrirouter-middleware-controller/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>11.2.0</version>
+        <version>11.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-domain/pom.xml
+++ b/agrirouter-middleware-domain/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>11.2.0</version>
+        <version>11.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-efdi/pom.xml
+++ b/agrirouter-middleware-efdi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>11.2.0</version>
+        <version>11.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-integration/pom.xml
+++ b/agrirouter-middleware-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>11.2.0</version>
+        <version>11.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/mqtt/MqttStatistics.java
+++ b/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/mqtt/MqttStatistics.java
@@ -71,7 +71,7 @@ public class MqttStatistics {
     }
 
     public void increaseNumberOfContentMessagesReceived(String technicalMessageType) {
-        Metrics.counter(NUMBER_OF_MESSAGES_ARRIVED, "technical_message_type", technicalMessageType).increment();
+        Metrics.counter(NUMBER_OF_MESSAGES_ARRIVED + "." + technicalMessageType).increment();
     }
 
     public void increasePayloadReceived(int length) {

--- a/agrirouter-middleware-isoxml/pom.xml
+++ b/agrirouter-middleware-isoxml/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>11.2.0</version>
+        <version>11.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-persistence/pom.xml
+++ b/agrirouter-middleware-persistence/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>11.2.0</version>
+        <version>11.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>de.agrirouter.middleware</groupId>
     <artifactId>agrirouter-middleware</artifactId>
-    <version>11.2.0</version>
+    <version>11.3.0</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -277,6 +277,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
+            <!--suppress KotlinMavenPluginPhase -->
             <artifactId>kotlin-stdlib</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -277,7 +277,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <!--suppress KotlinMavenPluginPhase -->
+            <!--suppress KotlinMavenPluginPhase: Suppressed to avoid redundant plugin phase execution for Kotlin standard library dependencies. -->
             <artifactId>kotlin-stdlib</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
This pull request updates the project version across multiple modules and makes a minor change to the metrics logic in the MQTT statistics class. Below is a detailed summary of the changes:

### Version Updates:
* Updated the project version from `11.2.0` to `11.3.0` in the following `pom.xml` files:
  - `agrirouter-middleware-api`
  - `agrirouter-middleware-application`
  - `agrirouter-middleware-business`
  - `agrirouter-middleware-controller`
  - `agrirouter-middleware-domain`
  - `agrirouter-middleware-efdi`
  - `agrirouter-middleware-integration`
  - `agrirouter-middleware-isoxml`
  - `agrirouter-middleware-persistence`
  - Root `pom.xml`

### Code Logic Adjustment:
* Modified the `increaseNumberOfContentMessagesReceived` method in `MqttStatistics.java` to use a concatenated metric name format (`NUMBER_OF_MESSAGES_ARRIVED + "." + technicalMessageType`) for better granularity in metrics tracking.

### Dependency Comment:
* Added a suppression comment for `KotlinMavenPluginPhase` in the `kotlin-stdlib` dependency section of the root `pom.xml`.