### PR TITLE
( ´ ∀ `)ノ～ ♡ | Bugfix/add record module for model mapper to solve problems with the mapping

### DIFF
--- a/agrirouter-middleware-application/pom.xml
+++ b/agrirouter-middleware-application/pom.xml
@@ -49,6 +49,10 @@
             <artifactId>modelmapper</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.modelmapper</groupId>
+            <artifactId>modelmapper-module-record</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.webjars.bower</groupId>
             <artifactId>material-design-lite</artifactId>
         </dependency>

--- a/agrirouter-middleware-application/src/main/java/de/agrirouter/middleware/config/BeanConfiguration.java
+++ b/agrirouter-middleware-application/src/main/java/de/agrirouter/middleware/config/BeanConfiguration.java
@@ -2,6 +2,7 @@ package de.agrirouter.middleware.config;
 
 import com.google.gson.Gson;
 import org.modelmapper.ModelMapper;
+import org.modelmapper.record.RecordModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -32,7 +33,9 @@ public class BeanConfiguration {
      */
     @Bean
     public ModelMapper modelMapper() {
-        return new ModelMapper();
+        var modelMapper = new ModelMapper();
+        modelMapper.registerModule(new RecordModule());
+        return modelMapper;
     }
 
     /**

--- a/agrirouter-middleware-controller/pom.xml
+++ b/agrirouter-middleware-controller/pom.xml
@@ -41,6 +41,10 @@
             <artifactId>modelmapper</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.modelmapper</groupId>
+            <artifactId>modelmapper-module-record</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>

--- a/agrirouter-middleware-controller/src/test/java/de/agrirouter/middleware/controller/secured/TelemetryPlatformControllerTest.java
+++ b/agrirouter-middleware-controller/src/test/java/de/agrirouter/middleware/controller/secured/TelemetryPlatformControllerTest.java
@@ -1,0 +1,34 @@
+package de.agrirouter.middleware.controller.secured;
+
+import de.agrirouter.middleware.business.dto.timelog.periods.TimeLogPeriod;
+import de.agrirouter.middleware.controller.dto.response.domain.timelog.periods.TimeLogPeriodDto;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.record.RecordModule;
+
+import java.util.Set;
+
+public class TelemetryPlatformControllerTest {
+
+    @Test
+    public void givenValidTimeLogPeriod_whenConvertingItToDto_thenTheConversionShouldBeSuccessful() {
+        var timeLogPeriod = new TimeLogPeriod(2L, 4L, 8, createRandomSetOfMessageIds());
+        var modelMapper = new ModelMapper().registerModule(new RecordModule());
+        var dto = modelMapper.map(timeLogPeriod, TimeLogPeriodDto.class);
+        Assertions.assertNotNull(dto);
+        Assertions.assertEquals(2L, dto.getBegin(), "The begin should be the same.");
+        Assertions.assertEquals(4L, dto.getEnd(), "The end should be the same.");
+        Assertions.assertEquals(8, dto.getNrOfTimeLogs(), "The number of time logs should be the same.");
+        Assertions.assertNull(dto.getHumanReadableBegin(), "The human readable begin should be null, since it is not set.");
+        Assertions.assertNull(dto.getHumanReadableEnd(), "The human readable end should be null, since it is not set.");
+    }
+
+    private Set<String> createRandomSetOfMessageIds() {
+        return Set.of("message_id_32", "message_id_64", "message_id_128", "message_id_256",
+                "message_id_512", "message_id_1024", "message_id_2048", "message_id_4096",
+                "message_id_8192", "message_id_16384", "message_id_32768", "message_id_65536",
+                "message_id_131072", "message_id_262144", "message_id_524288", "message_id_1048576");
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,11 @@
                 <artifactId>modelmapper</artifactId>
                 <version>3.2.4</version>
             </dependency>
+            <dependency>
+                <groupId>org.modelmapper</groupId>
+                <artifactId>modelmapper-module-record</artifactId>
+                <version>1.0.0</version>
+            </dependency>
 
             <!-- Client Name Decoders -->
             <dependency>


### PR DESCRIPTION
This pull request introduces support for Java records mapping using ModelMapper by adding the `modelmapper-module-record` dependency and updating configuration and tests to utilize it. The main goal is to ensure proper conversion between record-based DTOs and their mapped counterparts throughout the application and controller modules.

**Dependency updates:**

* Added `modelmapper-module-record` dependency to the root `pom.xml`, `agrirouter-middleware-application/pom.xml`, and `agrirouter-middleware-controller/pom.xml` to enable ModelMapper support for Java records. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R210-R214) [[2]](diffhunk://#diff-cbfad6aba8c743cd3bad4f9de094e37da7159f5053659a40e0ff1210025d7282R51-R54) [[3]](diffhunk://#diff-66015f5c02baa1638a86c70ce6850b82c629d2309a41fe0c970f3dc047aee5fdR43-R46)

**Configuration changes:**

* Updated the `modelMapper()` bean in `BeanConfiguration.java` to register the `RecordModule`, enabling ModelMapper to handle record types correctly. [[1]](diffhunk://#diff-eab68e2786e94248709e6c58721d10d7e645f73b71a335a634d828c1353c1f17R5) [[2]](diffhunk://#diff-eab68e2786e94248709e6c58721d10d7e645f73b71a335a634d828c1353c1f17L35-R38)

**Testing improvements:**

* Added `TelemetryPlatformControllerTest.java` to test and verify that ModelMapper can successfully map a `TimeLogPeriod` record to a `TimeLogPeriodDto`, ensuring the new record mapping functionality works as expected.