### PR TITLE
( ´ ∀ )ノ～ ♡ | Add support for marking notifications as read.

### DIFF
--- a/agrirouter-middleware-business/src/main/java/de/agrirouter/middleware/business/NotificationService.java
+++ b/agrirouter-middleware-business/src/main/java/de/agrirouter/middleware/business/NotificationService.java
@@ -50,4 +50,14 @@ public class NotificationService {
     public List<Notification> findAllByExternalEndpointIdAndEntityTypeAndChangeType(String externalEndpointId, EntityType entityType, ChangeType changeType) {
         return notificationRepository.findAllByExternalEndpointIdAndEntityTypeAndChangeType(externalEndpointId, entityType, changeType);
     }
+
+    /**
+     * Mark the notification as read and therefore remove it from the database.
+     *
+     * @param externalEndpointId The external endpoint ID.
+     * @param notificationId     The ID of the notification.
+     */
+    public void markAsRead(String externalEndpointId, String notificationId) {
+        notificationRepository.deleteByExternalEndpointIdAndId(externalEndpointId, notificationId);
+    }
 }

--- a/agrirouter-middleware-controller/src/main/java/de/agrirouter/middleware/controller/secured/NotificationController.java
+++ b/agrirouter-middleware-controller/src/main/java/de/agrirouter/middleware/controller/secured/NotificationController.java
@@ -16,10 +16,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -64,7 +61,7 @@ public class NotificationController {
                     )
             }
     )
-    public ResponseEntity<NotificationsResponse> findAllByExternalEndpointId(@Parameter(description = "The external endpoint ID.", required = true) @PathVariable String externalEndpointId) {
+    public ResponseEntity<?> findAllByExternalEndpointId(@Parameter(description = "The external endpoint ID.", required = true) @PathVariable String externalEndpointId) {
         var notifications = notificationService.findAllByExternalEndpointId(externalEndpointId);
         var dtos = convertToDtoList(notifications);
         return ResponseEntity.ok(new NotificationsResponse(dtos));
@@ -97,7 +94,7 @@ public class NotificationController {
                     )
             }
     )
-    public ResponseEntity<NotificationsResponse> findAllByExternalEndpointIdAndEntityType(@Parameter(description = "The external endpoint ID.", required = true) @PathVariable String externalEndpointId, @Parameter(description = "The entity type.", required = true) @PathVariable EntityType entityType) {
+    public ResponseEntity<?> findAllByExternalEndpointIdAndEntityType(@Parameter(description = "The external endpoint ID.", required = true) @PathVariable String externalEndpointId, @Parameter(description = "The entity type.", required = true) @PathVariable EntityType entityType) {
         var notifications = notificationService.findAllByExternalEndpointIdAndEntityType(externalEndpointId, entityType);
         var dtos = convertToDtoList(notifications);
         return ResponseEntity.ok(new NotificationsResponse(dtos));
@@ -131,10 +128,37 @@ public class NotificationController {
                     )
             }
     )
-    public ResponseEntity<NotificationsResponse> findAllByExternalEndpointIdAndEntityTypeAndChangeType(@Parameter(description = "The external endpoint ID.", required = true) @PathVariable String externalEndpointId, @Parameter(description = "The entity type.", required = true) @PathVariable EntityType entityType, @Parameter(description = "The change type.", required = true) @PathVariable ChangeType changeType) {
+    public ResponseEntity<?> findAllByExternalEndpointIdAndEntityTypeAndChangeType(@Parameter(description = "The external endpoint ID.", required = true) @PathVariable String externalEndpointId, @Parameter(description = "The entity type.", required = true) @PathVariable EntityType entityType, @Parameter(description = "The change type.", required = true) @PathVariable ChangeType changeType) {
         var notifications = notificationService.findAllByExternalEndpointIdAndEntityTypeAndChangeType(externalEndpointId, entityType, changeType);
         var dtos = convertToDtoList(notifications);
         return ResponseEntity.ok(new NotificationsResponse(dtos));
+    }
+
+    /**
+     * Mark the notification as read.
+     *
+     * @param externalEndpointId The external endpoint ID.
+     * @param notificationId     The ID of the notification.
+     */
+    @PostMapping("/{externalEndpointId}/{notificationId}")
+    @Operation(
+            summary = "Mark the notification as read.",
+            description = "This endpoint marks the notification as read.",
+            operationId = "notification.mark-as-read",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "In case the notification was marked as read."
+                    ),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "In case of an internal server error."
+                    )
+            }
+    )
+    public ResponseEntity<?> markAsRead(@PathVariable String externalEndpointId, @PathVariable String notificationId) {
+        notificationService.markAsRead(externalEndpointId, notificationId);
+        return ResponseEntity.ok().build();
     }
 
     @NotNull

--- a/agrirouter-middleware-persistence/src/main/java/de/agrirouter/middleware/persistence/mongo/NotificationRepository.java
+++ b/agrirouter-middleware-persistence/src/main/java/de/agrirouter/middleware/persistence/mongo/NotificationRepository.java
@@ -38,4 +38,12 @@ public interface NotificationRepository extends MongoRepository<Notification, St
      * @return The notifications.
      */
     List<Notification> findAllByExternalEndpointIdAndEntityTypeAndChangeType(String externalEndpointId, EntityType entityType, ChangeType changeType);
+
+    /**
+     * Delete the notification by the external endpoint ID and the notification ID.
+     *
+     * @param externalEndpointId The external endpoint ID.
+     * @param notificationId     The notification ID.
+     */
+    void deleteByExternalEndpointIdAndId(String externalEndpointId, String notificationId);
 }


### PR DESCRIPTION
This pull request introduces a new feature to mark notifications as read, which removes them from the database, and refactors several controller methods for improved flexibility. The main changes are grouped into new notification management functionality and controller response refactoring.

**Notification Management Enhancements:**

* Added a `markAsRead` method to `NotificationService` and corresponding `deleteByExternalEndpointIdAndId` method to `NotificationRepository` to allow notifications to be marked as read and deleted from the database. [[1]](diffhunk://#diff-cd838d3abf9f9b4456f0bc572f67a05d586a5fffb3ca11dad843016c48e8b9a7R53-R62) [[2]](diffhunk://#diff-c8a636fc0893bbb1139f5f881b9d671c1a1c652be828fd69bbedd5824a6e8024R41-R48)
* Introduced a new `POST` endpoint in `NotificationController` to mark notifications as read via API, with OpenAPI documentation for the endpoint.

**Controller Response Refactoring:**

* Changed return types for notification retrieval endpoints in `NotificationController` from `ResponseEntity<NotificationsResponse>` to more generic `ResponseEntity<?>` to allow greater flexibility in response handling. [[1]](diffhunk://#diff-1d4fd1bb4a653ba59c757bc3bb292f9c2ff7d6b2b45394133861997463bd8732L67-R64) [[2]](diffhunk://#diff-1d4fd1bb4a653ba59c757bc3bb292f9c2ff7d6b2b45394133861997463bd8732L100-R97) [[3]](diffhunk://#diff-1d4fd1bb4a653ba59c757bc3bb292f9c2ff7d6b2b45394133861997463bd8732L134-R163)
* Updated import statements in `NotificationController` to support new endpoint annotations and mapping.