### PR TITLE
( ´ ∀ )ノ～ ♡ | Refactor services to use Lombok's @RequiredArgsConstructor annotati…

### DIFF
--- a/agrirouter-middleware-business/src/main/java/de/agrirouter/middleware/business/security/AuthorizationService.java
+++ b/agrirouter-middleware-business/src/main/java/de/agrirouter/middleware/business/security/AuthorizationService.java
@@ -1,6 +1,7 @@
 package de.agrirouter.middleware.business.security;
 
 import de.agrirouter.middleware.persistence.jpa.ApplicationRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.security.Principal;
@@ -9,13 +10,10 @@ import java.security.Principal;
  * Service for authorization.
  */
 @Service
+@RequiredArgsConstructor
 public class AuthorizationService {
 
     private final ApplicationRepository applicationRepository;
-
-    public AuthorizationService(ApplicationRepository applicationRepository) {
-        this.applicationRepository = applicationRepository;
-    }
 
     /**
      * Check if the principal is authorized to access the given application.

--- a/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/EndpointIntegrationService.java
+++ b/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/EndpointIntegrationService.java
@@ -13,6 +13,7 @@ import de.agrirouter.middleware.integration.ack.MessageWaitingForAcknowledgement
 import de.agrirouter.middleware.integration.ack.MessageWaitingForAcknowledgementService;
 import de.agrirouter.middleware.integration.common.CapabilityParameterFactory;
 import de.agrirouter.middleware.integration.mqtt.MqttClientManagementService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -23,16 +24,11 @@ import java.util.List;
  */
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class EndpointIntegrationService {
 
     private final MessageWaitingForAcknowledgementService messageWaitingForAcknowledgementService;
     private final MqttClientManagementService mqttClientManagementService;
-
-    public EndpointIntegrationService(MessageWaitingForAcknowledgementService messageWaitingForAcknowledgementService,
-                                      MqttClientManagementService mqttClientManagementService) {
-        this.mqttClientManagementService = mqttClientManagementService;
-        this.messageWaitingForAcknowledgementService = messageWaitingForAcknowledgementService;
-    }
 
     /**
      * Send capabilities.

--- a/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/RevokeProcessIntegrationService.java
+++ b/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/RevokeProcessIntegrationService.java
@@ -5,6 +5,7 @@ import com.dke.data.agrirouter.api.service.RevokingService;
 import com.dke.data.agrirouter.api.service.parameters.RevokeParameters;
 import de.agrirouter.middleware.domain.Application;
 import de.agrirouter.middleware.domain.Endpoint;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -15,13 +16,10 @@ import java.util.Collections;
  */
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class RevokeProcessIntegrationService {
 
     private final RevokingService revokingService;
-
-    public RevokeProcessIntegrationService(RevokingService revokingService) {
-        this.revokingService = revokingService;
-    }
 
     /**
      * Revoke an existing endpoint.

--- a/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/SecuredOnboardProcessIntegrationService.java
+++ b/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/SecuredOnboardProcessIntegrationService.java
@@ -9,6 +9,7 @@ import com.dke.data.agrirouter.api.service.parameters.SecuredOnboardingParameter
 import de.agrirouter.middleware.api.errorhandling.BusinessException;
 import de.agrirouter.middleware.api.errorhandling.error.ErrorMessageFactory;
 import de.agrirouter.middleware.integration.parameters.SecuredOnboardProcessIntegrationParameters;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -18,16 +19,13 @@ import org.springframework.stereotype.Service;
  */
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class SecuredOnboardProcessIntegrationService {
 
     private final OnboardingService onboardingService;
 
     @Value("${app.signature-verification.disable:false}")
     private boolean disableVerification;
-
-    public SecuredOnboardProcessIntegrationService(OnboardingService onboardingService) {
-        this.onboardingService = onboardingService;
-    }
 
     /**
      * Secured onboard process.

--- a/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/SendMessageIntegrationService.java
+++ b/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/SendMessageIntegrationService.java
@@ -18,6 +18,7 @@ import de.agrirouter.middleware.integration.ack.MessageWaitingForAcknowledgement
 import de.agrirouter.middleware.integration.ack.MessageWaitingForAcknowledgementService;
 import de.agrirouter.middleware.integration.mqtt.MqttClientManagementService;
 import de.agrirouter.middleware.integration.parameters.MessagingIntegrationParameters;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
@@ -29,19 +30,12 @@ import java.util.ArrayList;
  */
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class SendMessageIntegrationService {
 
     private final MqttClientManagementService mqttClientManagementService;
     private final EncodeMessageService encodeMessageService;
     private final MessageWaitingForAcknowledgementService messageWaitingForAcknowledgementService;
-
-    public SendMessageIntegrationService(MqttClientManagementService mqttClientManagementService,
-                                         EncodeMessageService encodeMessageService,
-                                         MessageWaitingForAcknowledgementService messageWaitingForAcknowledgementService) {
-        this.mqttClientManagementService = mqttClientManagementService;
-        this.encodeMessageService = encodeMessageService;
-        this.messageWaitingForAcknowledgementService = messageWaitingForAcknowledgementService;
-    }
 
     /**
      * Publish a message. If the recipients are set also, the sending mode will be only direct sending, you have to decide between publishing and direct sending.

--- a/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/VirtualOffboardProcessIntegrationService.java
+++ b/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/VirtualOffboardProcessIntegrationService.java
@@ -10,6 +10,7 @@ import de.agrirouter.middleware.integration.ack.MessageWaitingForAcknowledgement
 import de.agrirouter.middleware.integration.ack.MessageWaitingForAcknowledgementService;
 import de.agrirouter.middleware.integration.mqtt.MqttClientManagementService;
 import de.agrirouter.middleware.integration.parameters.VirtualOffboardProcessIntegrationParameters;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -20,16 +21,11 @@ import java.util.HashMap;
  */
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class VirtualOffboardProcessIntegrationService {
 
     private final MqttClientManagementService mqttClientManagementService;
     private final MessageWaitingForAcknowledgementService messageWaitingForAcknowledgementService;
-
-    public VirtualOffboardProcessIntegrationService(MqttClientManagementService mqttClientManagementService,
-                                                    MessageWaitingForAcknowledgementService messageWaitingForAcknowledgementService) {
-        this.mqttClientManagementService = mqttClientManagementService;
-        this.messageWaitingForAcknowledgementService = messageWaitingForAcknowledgementService;
-    }
 
     /**
      * Virtual endpoint offboard process.

--- a/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/VirtualOnboardProcessIntegrationService.java
+++ b/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/VirtualOnboardProcessIntegrationService.java
@@ -11,6 +11,7 @@ import de.agrirouter.middleware.integration.ack.MessageWaitingForAcknowledgement
 import de.agrirouter.middleware.integration.container.VirtualEndpointOnboardStateContainer;
 import de.agrirouter.middleware.integration.mqtt.MqttClientManagementService;
 import de.agrirouter.middleware.integration.parameters.VirtualOnboardProcessIntegrationParameters;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
@@ -26,19 +27,12 @@ import static de.agrirouter.middleware.integration.ack.DynamicMessageProperties.
  */
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class VirtualOnboardProcessIntegrationService {
 
     private final MqttClientManagementService mqttClientManagementService;
     private final MessageWaitingForAcknowledgementService messageWaitingForAcknowledgementService;
     private final VirtualEndpointOnboardStateContainer virtualEndpointOnboardStateContainer;
-
-    public VirtualOnboardProcessIntegrationService(MqttClientManagementService mqttClientManagementService,
-                                                   MessageWaitingForAcknowledgementService messageWaitingForAcknowledgementService,
-                                                   VirtualEndpointOnboardStateContainer virtualEndpointOnboardStateContainer) {
-        this.mqttClientManagementService = mqttClientManagementService;
-        this.messageWaitingForAcknowledgementService = messageWaitingForAcknowledgementService;
-        this.virtualEndpointOnboardStateContainer = virtualEndpointOnboardStateContainer;
-    }
 
     /**
      * Virtual endpoint onboard process.

--- a/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/mqtt/list_endpoints/ListEndpointsIntegrationService.java
+++ b/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/mqtt/list_endpoints/ListEndpointsIntegrationService.java
@@ -8,6 +8,7 @@ import de.agrirouter.middleware.domain.Endpoint;
 import de.agrirouter.middleware.integration.ack.MessageWaitingForAcknowledgement;
 import de.agrirouter.middleware.integration.ack.MessageWaitingForAcknowledgementService;
 import de.agrirouter.middleware.integration.mqtt.MqttClientManagementService;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -20,19 +21,12 @@ import java.util.Optional;
  */
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class ListEndpointsIntegrationService {
 
     private final MqttClientManagementService mqttClientManagementService;
     private final MessageWaitingForAcknowledgementService messageWaitingForAcknowledgementService;
     private final ListEndpointsMessages listEndpointsMessages;
-
-    public ListEndpointsIntegrationService(MqttClientManagementService mqttClientManagementService,
-                                           MessageWaitingForAcknowledgementService messageWaitingForAcknowledgementService,
-                                           ListEndpointsMessages listEndpointsMessages) {
-        this.mqttClientManagementService = mqttClientManagementService;
-        this.messageWaitingForAcknowledgementService = messageWaitingForAcknowledgementService;
-        this.listEndpointsMessages = listEndpointsMessages;
-    }
 
     /**
      * Publish a list endpoints message for the given onboarding response.


### PR DESCRIPTION
This pull request refactors several service classes to use Lombok's `@RequiredArgsConstructor` annotation, simplifying constructor injection for dependencies and reducing boilerplate code. Instead of manually defining constructors for dependency injection, the annotation automatically generates them, making the codebase cleaner and easier to maintain.

Dependency injection improvements:

* Added the `@RequiredArgsConstructor` annotation to multiple service classes (`AuthorizationService`, `EndpointIntegrationService`, `RevokeProcessIntegrationService`, `SecuredOnboardProcessIntegrationService`, `SendMessageIntegrationService`, `VirtualOffboardProcessIntegrationService`, `VirtualOnboardProcessIntegrationService`, and `ListEndpointsIntegrationService`) to automatically generate constructors for final fields. [[1]](diffhunk://#diff-df54e94f2e63d7ce92270b375c16bbd1f7d2b8d80d4c73421f6629f2287a0a50R4) [[2]](diffhunk://#diff-58cd6c43c8a4747173d4633fefb398d14ddc373aaee98f9646aa199ac1c7cb5aR16) [[3]](diffhunk://#diff-44895687e73d822415f39e4c0f1e92a3390bc946bf56c3a32294317bef295837R8) [[4]](diffhunk://#diff-f6bd2777e8e8c14cf779b9ba5b73a775c42c2c587b41f70d51b33a163c6b1a7eR12) [[5]](diffhunk://#diff-f025228f9841072e469612aa45eaf7b556c8f57c84ac63e3da0dec825a219a1bR21) [[6]](diffhunk://#diff-cd84f0adf96a1bf81c2d2665397f22db7f25668cd1d0fa31f8b4ae4518ba21b1R13) [[7]](diffhunk://#diff-3581bcb09544dc95aecba60365508f35bb0b39fb8515b95392a11dfb1c359e28R14) [[8]](diffhunk://#diff-23085099cd9b2ef07f934a0642b87f70210baf567873cc2caa454a2b9509eecbR11)

Codebase simplification:

* Removed manual constructor definitions from all affected service classes, relying on Lombok to handle constructor generation and thus reducing boilerplate code. [[1]](diffhunk://#diff-df54e94f2e63d7ce92270b375c16bbd1f7d2b8d80d4c73421f6629f2287a0a50R13-L19) [[2]](diffhunk://#diff-58cd6c43c8a4747173d4633fefb398d14ddc373aaee98f9646aa199ac1c7cb5aR27-L36) [[3]](diffhunk://#diff-44895687e73d822415f39e4c0f1e92a3390bc946bf56c3a32294317bef295837R19-L25) [[4]](diffhunk://#diff-f6bd2777e8e8c14cf779b9ba5b73a775c42c2c587b41f70d51b33a163c6b1a7eR22-L31) [[5]](diffhunk://#diff-f025228f9841072e469612aa45eaf7b556c8f57c84ac63e3da0dec825a219a1bR33-L45) [[6]](diffhunk://#diff-cd84f0adf96a1bf81c2d2665397f22db7f25668cd1d0fa31f8b4ae4518ba21b1R24-L33) [[7]](diffhunk://#diff-3581bcb09544dc95aecba60365508f35bb0b39fb8515b95392a11dfb1c359e28R30-L42) [[8]](diffhunk://#diff-23085099cd9b2ef07f934a0642b87f70210baf567873cc2caa454a2b9509eecbR24-L36)…on**