### PR TITLE
( ´ ∀ )ノ～ ♡ | Optimize TemporaryContentMessageType key lookup with constant time m…

### DIFF
--- a/agrirouter-middleware-domain/src/main/java/de/agrirouter/middleware/domain/enums/TemporaryContentMessageType.java
+++ b/agrirouter-middleware-domain/src/main/java/de/agrirouter/middleware/domain/enums/TemporaryContentMessageType.java
@@ -5,6 +5,10 @@ import com.dke.data.agrirouter.api.enums.TechnicalMessageType;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 @Getter
 @RequiredArgsConstructor
 public enum TemporaryContentMessageType implements TechnicalMessageType {
@@ -35,6 +39,16 @@ public enum TemporaryContentMessageType implements TechnicalMessageType {
     private final String typeUrl;
     private final boolean needsBase64Encoding;
 
+    private static final Map<String, TemporaryContentMessageType> LOOKUP_BY_KEY;
+
+    static {
+        java.util.Map<String, TemporaryContentMessageType> map = new HashMap<>();
+        for (TemporaryContentMessageType t : values()) {
+            map.put(t.key, t);
+        }
+        LOOKUP_BY_KEY = Collections.unmodifiableMap(map);
+    }
+
     @Override
     public boolean needsBase64EncodingAndHasToBeChunkedIfNecessary() {
         return needsBase64Encoding;
@@ -49,13 +63,9 @@ public enum TemporaryContentMessageType implements TechnicalMessageType {
      * otherwise, returns null.
      */
     public static TemporaryContentMessageType fromKey(String key) {
-        if (key != null) {
-            for (var t : values()) {
-                if (t.getKey().equals(key)) {
-                    return t;
-                }
-            }
+        if (key == null) {
+            return null;
         }
-        return null;
+        return LOOKUP_BY_KEY.get(key);
     }
 }


### PR DESCRIPTION
This pull request refactors the `TemporaryContentMessageType` enum to optimize the lookup of message types by their key. The main change is replacing the previous linear search with a static, immutable map for faster and more efficient retrieval.

Performance and code maintainability improvements:

* Added a static, immutable `LOOKUP_BY_KEY` map to cache all enum instances by their key, improving lookup performance in `fromKey`.
* Refactored the `fromKey` method to use the new `LOOKUP_BY_KEY` map instead of iterating through all enum values, simplifying the code and reducing time complexity.

Imports and dependencies:

* Added necessary imports for `Collections`, `HashMap`, and `Map` to support the new lookup mechanism.…ap approach"