### PR TITLE
feat(mqtt): add PEM certificate support for MQTT connections

### DIFF
--- a/agrirouter-middleware-api/pom.xml
+++ b/agrirouter-middleware-api/pom.xml
@@ -36,6 +36,10 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/agrirouter-middleware-api/pom.xml
+++ b/agrirouter-middleware-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>12.0.0</version>
+        <version>12.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-application/pom.xml
+++ b/agrirouter-middleware-application/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>12.0.0</version>
+        <version>12.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-business/pom.xml
+++ b/agrirouter-middleware-business/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>12.0.0</version>
+        <version>12.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-controller/pom.xml
+++ b/agrirouter-middleware-controller/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>12.0.0</version>
+        <version>12.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-domain/pom.xml
+++ b/agrirouter-middleware-domain/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>12.0.0</version>
+        <version>12.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-efdi/pom.xml
+++ b/agrirouter-middleware-efdi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>12.0.0</version>
+        <version>12.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-integration/pom.xml
+++ b/agrirouter-middleware-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>12.0.0</version>
+        <version>12.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/mqtt/MqttConnectionManager.java
+++ b/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/mqtt/MqttConnectionManager.java
@@ -210,7 +210,7 @@ public class MqttConnectionManager {
             var certificateMatcher = Pattern.compile("-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----", Pattern.DOTALL).matcher(authentication.getCertificate());
             var certificatesJoined = new StringBuilder();
             while (certificateMatcher.find()) {
-                certificatesJoined.append(certificateMatcher.group());
+                certificatesJoined.append(certificateMatcher.group()).append(System.lineSeparator());
             }
             var certificates = cf.generateCertificates(new ByteArrayInputStream(certificatesJoined.toString().getBytes()));
             var certificateChain = certificates.toArray(new Certificate[0]);

--- a/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/mqtt/MqttConnectionManager.java
+++ b/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/mqtt/MqttConnectionManager.java
@@ -1,6 +1,7 @@
 package de.agrirouter.middleware.integration.mqtt;
 
 import com.dke.data.agrirouter.api.dto.onboard.OnboardingResponse;
+import com.dke.data.agrirouter.api.enums.CertificationType;
 import com.dke.data.agrirouter.api.exception.CouldNotCreateMqttClientException;
 import com.hivemq.client.mqtt.MqttClientSslConfig;
 import com.hivemq.client.mqtt.mqtt3.Mqtt3AsyncClient;
@@ -21,14 +22,23 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
+import javax.crypto.EncryptedPrivateKeyInfo;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManagerFactory;
 import java.io.ByteArrayInputStream;
+import java.security.KeyFactory;
 import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.regex.Pattern;
 
 @Slf4j
 @Component
@@ -195,7 +205,51 @@ public class MqttConnectionManager {
 
     private MqttClientSslConfig createMqttClientSslConfig(de.agrirouter.middleware.domain.Authentication authentication) throws Exception {
         var keyStore = KeyStore.getInstance("PKCS12");
-        keyStore.load(new ByteArrayInputStream(Base64.getDecoder().decode(authentication.getCertificate())), authentication.getSecret().toCharArray());
+        if (CertificationType.PEM.equals(authentication.getType())) {
+            var cf = CertificateFactory.getInstance("X.509");
+            var certificateMatcher = Pattern.compile("-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----", Pattern.DOTALL).matcher(authentication.getCertificate());
+            var certificatesJoined = new StringBuilder();
+            while (certificateMatcher.find()) {
+                certificatesJoined.append(certificateMatcher.group());
+            }
+            var certificates = cf.generateCertificates(new ByteArrayInputStream(certificatesJoined.toString().getBytes()));
+            var certificateChain = certificates.toArray(new Certificate[0]);
+
+            var privateKeyMatcher = Pattern.compile("-----BEGIN.*?PRIVATE KEY-----.*?-----END.*?PRIVATE KEY-----", Pattern.DOTALL).matcher(authentication.getCertificate());
+            if (privateKeyMatcher.find()) {
+                var privateKeyPem = privateKeyMatcher.group();
+                var base64Key = privateKeyPem
+                        .replace("-----BEGIN ENCRYPTED PRIVATE KEY-----", "")
+                        .replace("-----END ENCRYPTED PRIVATE KEY-----", "")
+                        .replace("-----BEGIN PRIVATE KEY-----", "")
+                        .replace("-----END PRIVATE KEY-----", "")
+                        .replace("-----BEGIN RSA PRIVATE KEY-----", "")
+                        .replace("-----END RSA PRIVATE KEY-----", "")
+                        .replaceAll("\\s", "");
+                var decodedKey = Base64.getDecoder().decode(base64Key);
+
+                PrivateKey privateKey;
+                if (privateKeyPem.contains("ENCRYPTED")) {
+                    var encKeyInfo = new EncryptedPrivateKeyInfo(decodedKey);
+                    var skf = SecretKeyFactory.getInstance(encKeyInfo.getAlgName());
+                    var pbeKeySpec = new PBEKeySpec(authentication.getSecret().toCharArray());
+                    var secretKey = skf.generateSecret(pbeKeySpec);
+                    var pkcs8Spec = encKeyInfo.getKeySpec(secretKey);
+                    var kf = KeyFactory.getInstance("RSA");
+                    privateKey = kf.generatePrivate(pkcs8Spec);
+                } else {
+                    var kf = KeyFactory.getInstance("RSA");
+                    privateKey = kf.generatePrivate(new PKCS8EncodedKeySpec(decodedKey));
+                }
+
+                keyStore.load(null, null);
+                keyStore.setKeyEntry("client", privateKey, authentication.getSecret().toCharArray(), certificateChain);
+            } else {
+                throw new IllegalArgumentException("No private key found in the PEM certificate.");
+            }
+        } else {
+            keyStore.load(new ByteArrayInputStream(Base64.getDecoder().decode(authentication.getCertificate())), authentication.getSecret().toCharArray());
+        }
 
         var keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
         keyManagerFactory.init(keyStore, authentication.getSecret().toCharArray());

--- a/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/mqtt/MqttConnectionManager.java
+++ b/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/mqtt/MqttConnectionManager.java
@@ -236,7 +236,7 @@ public class MqttConnectionManager {
                 keyStore.load(null, null);
                 keyStore.setKeyEntry("client", privateKey, authentication.getSecret().toCharArray(), certificateChain);
             } else {
-                throw new IllegalArgumentException("No private key found in the PEM certificate.");
+                throw new IllegalArgumentException("No encrypted private key found in the provided PEM content. Expected an encrypted PKCS#8 PEM block (-----BEGIN ENCRYPTED PRIVATE KEY-----).");
             }
         } else {
             keyStore.load(new ByteArrayInputStream(Base64.getDecoder().decode(authentication.getCertificate())), authentication.getSecret().toCharArray());

--- a/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/mqtt/MqttConnectionManager.java
+++ b/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/mqtt/MqttConnectionManager.java
@@ -213,6 +213,9 @@ public class MqttConnectionManager {
                 certificatesJoined.append(certificateMatcher.group()).append(System.lineSeparator());
             }
             var certificates = cf.generateCertificates(new ByteArrayInputStream(certificatesJoined.toString().getBytes()));
+            if (certificates.isEmpty()) {
+                throw new IllegalArgumentException("PEM authentication was selected, but no X.509 certificate was found in the provided PEM content.");
+            }
             var certificateChain = certificates.toArray(new Certificate[0]);
 
             var privateKeyMatcher = Pattern.compile("-----BEGIN.*?PRIVATE KEY-----.*?-----END.*?PRIVATE KEY-----", Pattern.DOTALL).matcher(authentication.getCertificate());

--- a/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/mqtt/MqttConnectionManager.java
+++ b/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/mqtt/MqttConnectionManager.java
@@ -30,10 +30,8 @@ import javax.net.ssl.TrustManagerFactory;
 import java.io.ByteArrayInputStream;
 import java.security.KeyFactory;
 import java.security.KeyStore;
-import java.security.PrivateKey;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
-import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -215,32 +213,22 @@ public class MqttConnectionManager {
             var certificates = cf.generateCertificates(new ByteArrayInputStream(certificatesJoined.toString().getBytes()));
             var certificateChain = certificates.toArray(new Certificate[0]);
 
-            var privateKeyMatcher = Pattern.compile("-----BEGIN.*?PRIVATE KEY-----.*?-----END.*?PRIVATE KEY-----", Pattern.DOTALL).matcher(authentication.getCertificate());
+            var privateKeyMatcher = Pattern.compile("-----BEGIN ENCRYPTED PRIVATE KEY-----.*?-----END ENCRYPTED PRIVATE KEY-----", Pattern.DOTALL).matcher(authentication.getCertificate());
             if (privateKeyMatcher.find()) {
                 var privateKeyPem = privateKeyMatcher.group();
                 var base64Key = privateKeyPem
                         .replace("-----BEGIN ENCRYPTED PRIVATE KEY-----", "")
                         .replace("-----END ENCRYPTED PRIVATE KEY-----", "")
-                        .replace("-----BEGIN PRIVATE KEY-----", "")
-                        .replace("-----END PRIVATE KEY-----", "")
-                        .replace("-----BEGIN RSA PRIVATE KEY-----", "")
-                        .replace("-----END RSA PRIVATE KEY-----", "")
                         .replaceAll("\\s", "");
                 var decodedKey = Base64.getDecoder().decode(base64Key);
 
-                PrivateKey privateKey;
-                if (privateKeyPem.contains("ENCRYPTED")) {
-                    var encKeyInfo = new EncryptedPrivateKeyInfo(decodedKey);
-                    var skf = SecretKeyFactory.getInstance(encKeyInfo.getAlgName());
-                    var pbeKeySpec = new PBEKeySpec(authentication.getSecret().toCharArray());
-                    var secretKey = skf.generateSecret(pbeKeySpec);
-                    var pkcs8Spec = encKeyInfo.getKeySpec(secretKey);
-                    var kf = KeyFactory.getInstance("RSA");
-                    privateKey = kf.generatePrivate(pkcs8Spec);
-                } else {
-                    var kf = KeyFactory.getInstance("RSA");
-                    privateKey = kf.generatePrivate(new PKCS8EncodedKeySpec(decodedKey));
-                }
+                var encKeyInfo = new EncryptedPrivateKeyInfo(decodedKey);
+                var skf = SecretKeyFactory.getInstance(encKeyInfo.getAlgName());
+                var pbeKeySpec = new PBEKeySpec(authentication.getSecret().toCharArray());
+                var secretKey = skf.generateSecret(pbeKeySpec);
+                var pkcs8Spec = encKeyInfo.getKeySpec(secretKey);
+                var kf = KeyFactory.getInstance("RSA");
+                var privateKey = kf.generatePrivate(pkcs8Spec);
 
                 keyStore.load(null, null);
                 keyStore.setKeyEntry("client", privateKey, authentication.getSecret().toCharArray(), certificateChain);

--- a/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/mqtt/MqttConnectionManager.java
+++ b/agrirouter-middleware-integration/src/main/java/de/agrirouter/middleware/integration/mqtt/MqttConnectionManager.java
@@ -28,6 +28,7 @@ import javax.crypto.spec.PBEKeySpec;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManagerFactory;
 import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
@@ -210,7 +211,7 @@ public class MqttConnectionManager {
             while (certificateMatcher.find()) {
                 certificatesJoined.append(certificateMatcher.group()).append(System.lineSeparator());
             }
-            var certificates = cf.generateCertificates(new ByteArrayInputStream(certificatesJoined.toString().getBytes()));
+            var certificates = cf.generateCertificates(new ByteArrayInputStream(certificatesJoined.toString().getBytes(StandardCharsets.UTF_8)));
             if (certificates.isEmpty()) {
                 throw new IllegalArgumentException("PEM authentication was selected, but no X.509 certificate was found in the provided PEM content.");
             }

--- a/agrirouter-middleware-isoxml/pom.xml
+++ b/agrirouter-middleware-isoxml/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>12.0.0</version>
+        <version>12.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-persistence/pom.xml
+++ b/agrirouter-middleware-persistence/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>12.0.0</version>
+        <version>12.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,13 @@
                 <version>3.1.0</version>
             </dependency>
 
+            <!-- JACKSON -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>2.18.2</version>
+            </dependency>
+
             <!-- COMMONS CODEC -->
             <dependency>
                 <groupId>commons-codec</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>de.agrirouter.middleware</groupId>
     <artifactId>agrirouter-middleware</artifactId>
-    <version>12.0.0</version>
+    <version>12.1.0</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
This pull request enhances the `MqttConnectionManager` to support PEM certificate handling in addition to existing PKCS12 support. The main changes focus on parsing and loading PEM certificates and private keys, including support for both encrypted and unencrypted private keys.

**PEM Certificate and Private Key Handling:**

* Added logic to detect when the authentication type is PEM and parse certificates and private keys from the PEM-encoded content, supporting both encrypted and unencrypted keys. Throws an error if a private key is not found.
* Utilizes regular expressions to extract certificate and private key blocks from the PEM string, and uses Java security APIs to decode and load them into a `KeyStore`.

**Dependency and Import Updates:**

* Added imports for Java security and cryptography classes (`CertificateFactory`, `PrivateKey`, `EncryptedPrivateKeyInfo`, etc.) and utility classes needed for PEM parsing and key handling. [[1]](diffhunk://#diff-137dd05007a35169f7df384d2a8e9e99a7e5f0020cd9e5d1ef291822ece2da18R4) [[2]](diffhunk://#diff-137dd05007a35169f7df384d2a8e9e99a7e5f0020cd9e5d1ef291822ece2da18R25-R41)

These changes ensure that the middleware can now establish MQTT connections using credentials provided in PEM format, improving compatibility with a wider range of authentication mechanisms.Support parsing and handling PEM-encoded certificates and private keys for MQTT client SSL configuration.