### PR TITLE
chore(pom): bump parent version to 12.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ message-cache
 
 # MAC_OS #
 .DS_Store
+
+# GPG significant files
+gpg_signingkey.key

--- a/agrirouter-middleware-api/pom.xml
+++ b/agrirouter-middleware-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>12.1.0</version>
+        <version>12.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-application/pom.xml
+++ b/agrirouter-middleware-application/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>12.1.0</version>
+        <version>12.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-business/pom.xml
+++ b/agrirouter-middleware-business/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>12.1.0</version>
+        <version>12.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-controller/pom.xml
+++ b/agrirouter-middleware-controller/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>12.1.0</version>
+        <version>12.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-domain/pom.xml
+++ b/agrirouter-middleware-domain/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>12.1.0</version>
+        <version>12.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-efdi/pom.xml
+++ b/agrirouter-middleware-efdi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>12.1.0</version>
+        <version>12.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-integration/pom.xml
+++ b/agrirouter-middleware-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>12.1.0</version>
+        <version>12.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-isoxml/pom.xml
+++ b/agrirouter-middleware-isoxml/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>12.1.0</version>
+        <version>12.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-persistence/pom.xml
+++ b/agrirouter-middleware-persistence/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>12.1.0</version>
+        <version>12.1.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>de.agrirouter.middleware</groupId>
     <artifactId>agrirouter-middleware</artifactId>
-    <version>12.1.0</version>
+    <version>12.1.1</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
This pull request updates the version of the parent Maven project and all related modules from `12.1.0` to `12.1.1`. This ensures that all submodules and the main project are aligned to the latest version.

Version updates:

* Updated the parent project version in the root `pom.xml` from `12.1.0` to `12.1.1`.
* Updated the parent version reference to `12.1.1` in the following module `pom.xml` files:
  - `agrirouter-middleware-api/pom.xml`
  - `agrirouter-middleware-application/pom.xml`
  - `agrirouter-middleware-business/pom.xml`
  - `agrirouter-middleware-controller/pom.xml`
  - `agrirouter-middleware-domain/pom.xml`
  - `agrirouter-middleware-efdi/pom.xml`
  - `agrirouter-middleware-integration/pom.xml`
  - `agrirouter-middleware-isoxml/pom.xml`
  - `agrirouter-middleware-persistence/pom.xml`