### PR TITLE
Bugfix: fix thymeleaf security context error introduced with newer thymeleaf version

### DIFF
--- a/agrirouter-middleware-application/src/main/java/de/agrirouter/middleware/controller/aop/BrandingUIControllerAdvice.java
+++ b/agrirouter-middleware-application/src/main/java/de/agrirouter/middleware/controller/aop/BrandingUIControllerAdvice.java
@@ -1,0 +1,39 @@
+package de.agrirouter.middleware.controller.aop;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+/**
+ * Controller advice to add branding information to the model.
+ */
+@ControllerAdvice
+public class BrandingUIControllerAdvice {
+
+    @Value("${app.branding.favicon}")
+    private String favicon;
+
+    @Value("${app.branding.customCss:#{null}}")
+    private String customCss;
+
+    /**
+     * Add the favicon to the model.
+     *
+     * @return The favicon.
+     */
+    @ModelAttribute("favicon")
+    public String favicon() {
+        return favicon;
+    }
+
+    /**
+     * Add the custom CSS to the model.
+     *
+     * @return The custom CSS.
+     */
+    @ModelAttribute("customCss")
+    public String customCss() {
+        return customCss;
+    }
+
+}

--- a/agrirouter-middleware-application/src/main/resources/templates/fragments/layout-without-menu.html
+++ b/agrirouter-middleware-application/src/main/resources/templates/fragments/layout-without-menu.html
@@ -6,7 +6,7 @@
     <title th:replace="${title}">Layout Title</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <link rel="stylesheet" href="webjars/material-design-lite/1.3.0/material.min.css"/>
-    <link rel="shortcut icon" type="image/png" th:href="${favicon}"/>
+    <link rel="shortcut icon" type="image/png" th:href="@{${favicon}}"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.blue_grey-light_green.min.css"/>
     <link rel="stylesheet" type="text/css" th:href="${customCss}"

--- a/agrirouter-middleware-application/src/main/resources/templates/fragments/layout-without-menu.html
+++ b/agrirouter-middleware-application/src/main/resources/templates/fragments/layout-without-menu.html
@@ -6,14 +6,14 @@
     <title th:replace="${title}">Layout Title</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <link rel="stylesheet" href="webjars/material-design-lite/1.3.0/material.min.css"/>
-    <link rel="shortcut icon" type="image/png" th:href="@{/img/favicon.ico}"/>
+    <link rel="shortcut icon" type="image/png" th:href="${favicon}"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.blue_grey-light_green.min.css"/>
-    <link rel="stylesheet" type="text/css" th:href="${@environment.getProperty('app.branding.customCss')}"
-          th:if="${@environment.getProperty('app.branding.customCss') != null
-              and (#strings.startsWith(@environment.getProperty('app.branding.customCss'), 'http://')
-                   or #strings.startsWith(@environment.getProperty('app.branding.customCss'), 'https://')
-                   or #strings.startsWith(@environment.getProperty('app.branding.customCss'), '/'))}"/>
+    <link rel="stylesheet" type="text/css" th:href="${customCss}"
+          th:if="${customCss != null
+              and (customCss.startsWith('http://')
+                   or customCss.startsWith('https://')
+                   or customCss.startsWith('/'))}"/>
 </head>
 <body>
 <div class="container">

--- a/agrirouter-middleware-application/src/main/resources/templates/fragments/layout.html
+++ b/agrirouter-middleware-application/src/main/resources/templates/fragments/layout.html
@@ -8,7 +8,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <link rel="stylesheet" type="text/css" th:href="@{/webjars/material-design-lite/1.3.0/material.min.css}"/>
     <link rel="stylesheet" type="text/css" th:href="@{/css/application.css}">
-    <link rel="shortcut icon" type="image/png" th:href="${favicon}"/>
+    <link rel="shortcut icon" type="image/png" th:href="@{${favicon}}"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.blue_grey-light_green.min.css"/>
     <link rel="stylesheet" type="text/css" th:href="${customCss}"

--- a/agrirouter-middleware-application/src/main/resources/templates/fragments/layout.html
+++ b/agrirouter-middleware-application/src/main/resources/templates/fragments/layout.html
@@ -8,11 +8,11 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <link rel="stylesheet" type="text/css" th:href="@{/webjars/material-design-lite/1.3.0/material.min.css}"/>
     <link rel="stylesheet" type="text/css" th:href="@{/css/application.css}">
-    <link rel="shortcut icon" type="image/png" th:href="${@environment.getProperty('app.branding.favicon')}"/>
+    <link rel="shortcut icon" type="image/png" th:href="${favicon}"/>
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
     <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.blue_grey-light_green.min.css"/>
-    <link rel="stylesheet" type="text/css" th:href="${@environment.getProperty('app.branding.customCss')}"
-          th:if="${@environment.getProperty('app.branding.customCss') != null and (@environment.getProperty('app.branding.customCss').matches('^(https?://|/).*'))}"/>
+    <link rel="stylesheet" type="text/css" th:href="${customCss}"
+          th:if="${customCss != null and (customCss.matches('^(https?://|/).*'))}"/>
 </head>
 <body>
 <div class="container">


### PR DESCRIPTION
**Problem:**
The web interface was not showing anything but a white page with an http error 500 as the application was encountering a `TemplateProcessingException` with the message: *"Instantiation of new objects and access to static classes or parameters is forbidden in this context"*. This occurred in Thymeleaf templates when attempting to access the Spring `@environment` bean directly. This behavior is restricted in newer Thymeleaf versions (3.1+) for security reasons.

**Solution:**
To resolve this, the direct dependency on the environment bean within the HTML templates was removed. Instead, the required configuration values (`favicon` and `customCss`) are now provided to the view via a global controller advice.

**Changes:**
- **Added `BrandingUIControllerAdvice`**: Created a new `@ControllerAdvice` class that uses `@ModelAttribute` to automatically inject branding properties (`app.branding.favicon` and `app.branding.customCss`) into all UI controllers.
- **Updated Templates**: Refactored `layout.html` and `layout-without-menu.html` to use the injected model attributes (`${favicon}`, `${customCss}`) instead of calling `${@environment.getProperty(...)}`.
- **Improved Consistency**: Ensured both layout fragments use the same branding logic for a consistent user interface.

- Added `BrandingUIControllerAdvice` to inject favicon and custom CSS into the model.
- Updated layouts to use model attributes for favicon and custom CSS dynamically.