### PR TITLE
Bugfix: resolve potential logic error for URL handling in onboarding flow

### DIFF
--- a/agrirouter-middleware-business/src/main/java/de/agrirouter/middleware/business/SecuredOnboardProcessService.java
+++ b/agrirouter-middleware-business/src/main/java/de/agrirouter/middleware/business/SecuredOnboardProcessService.java
@@ -59,15 +59,8 @@ public class SecuredOnboardProcessService {
             final var parameters = new AuthorizationRequestParameters();
             parameters.setApplicationId(application.getApplicationId());
             parameters.setResponseType(SecuredOnboardingResponseType.ONBOARD);
-            var applicationSettingsRedirectUrl = application.getApplicationSettings().getRedirectUrl();
-            final String redirectUrlToUse;
-            if (StringUtils.isNotBlank(redirectUrl)) {
-                redirectUrlToUse = redirectUrl;
-            } else {
-                redirectUrlToUse = applicationSettingsRedirectUrl;
-            }
-            parameters.setRedirectUri(redirectUrlToUse);
-            parameters.setState(onboardStateContainer.push(application.getInternalApplicationId(), externalEndpointId, application.getTenant().getTenantId(), redirectUrlToUse));
+            parameters.setRedirectUri(application.getApplicationSettings().getRedirectUrl());
+            parameters.setState(onboardStateContainer.push(application.getInternalApplicationId(), externalEndpointId, application.getTenant().getTenantId(), redirectUrl));
             return authorizationRequestService.getAuthorizationRequestURL(parameters);
         }
     }

--- a/agrirouter-middleware-business/src/test/java/de/agrirouter/middleware/business/SecuredOnboardProcessServiceTest.java
+++ b/agrirouter-middleware-business/src/test/java/de/agrirouter/middleware/business/SecuredOnboardProcessServiceTest.java
@@ -42,14 +42,15 @@ class SecuredOnboardProcessServiceTest {
     @Test
     void generateAuthorizationUrl_withRedirectUrlParameter_shouldSetRedirectUri() {
         // Arrange
+        var applicationSettingsRedirectUrl = "https://production.example.com/callback";
         var customRedirectUrl = "http://localhost:5117/unsecured/api/callback";
         var applicationId = "test-app-id";
         var externalEndpointId = "test-endpoint-id";
         var tenantId = "test-tenant-id";
         var state = "random-state";
 
-        var application = createApplication(applicationId, tenantId);
-        
+        var application = createApplicationWithRedirectUrl(applicationId, tenantId, applicationSettingsRedirectUrl);
+
         when(onboardStateContainer.push(any(), any(), any(), eq(customRedirectUrl)))
                 .thenReturn(state);
         when(authorizationRequestService.getAuthorizationRequestURL(any()))
@@ -61,16 +62,16 @@ class SecuredOnboardProcessServiceTest {
         // Assert
         var captor = ArgumentCaptor.forClass(AuthorizationRequestParameters.class);
         verify(authorizationRequestService).getAuthorizationRequestURL(captor.capture());
-        
+
         var capturedParams = captor.getValue();
-        assertThat(capturedParams.getRedirectUri()).isEqualTo(customRedirectUrl);
+        assertThat(capturedParams.getRedirectUri()).isEqualTo(applicationSettingsRedirectUrl);
         assertThat(capturedParams.getApplicationId()).isEqualTo(applicationId);
         assertThat(capturedParams.getResponseType()).isEqualTo(SecuredOnboardingResponseType.ONBOARD);
         assertThat(capturedParams.getState()).isEqualTo(state);
     }
 
     @Test
-    void generateAuthorizationUrl_withoutRedirectUrlParameter_shouldUseApplicationSettingsRedirectUrl() {
+    void generateAuthorizationUrl_withoutRedirectUrlParameter_shouldNotUseApplicationSettingsRedirectUrl() {
         // Arrange
         var applicationSettingsRedirectUrl = "https://production.example.com/callback";
         var applicationId = "test-app-id";
@@ -79,8 +80,8 @@ class SecuredOnboardProcessServiceTest {
         var state = "random-state";
 
         var application = createApplicationWithRedirectUrl(applicationId, tenantId, applicationSettingsRedirectUrl);
-        
-        when(onboardStateContainer.push(any(), any(), any(), eq(applicationSettingsRedirectUrl)))
+
+        when(onboardStateContainer.push(any(), any(), any(), eq(null)))
                 .thenReturn(state);
         when(authorizationRequestService.getAuthorizationRequestURL(any()))
                 .thenReturn("http://agrirouter.example/authorize?state=" + state);
@@ -91,7 +92,7 @@ class SecuredOnboardProcessServiceTest {
         // Assert
         var captor = ArgumentCaptor.forClass(AuthorizationRequestParameters.class);
         verify(authorizationRequestService).getAuthorizationRequestURL(captor.capture());
-        
+
         var capturedParams = captor.getValue();
         assertThat(capturedParams.getRedirectUri()).isEqualTo(applicationSettingsRedirectUrl);
         assertThat(capturedParams.getApplicationId()).isEqualTo(applicationId);
@@ -100,7 +101,7 @@ class SecuredOnboardProcessServiceTest {
     }
 
     @Test
-    void generateAuthorizationUrl_withEmptyRedirectUrlParameter_shouldUseApplicationSettingsRedirectUrl() {
+    void generateAuthorizationUrl_withEmptyRedirectUrlParameter_shouldNotUseApplicationSettingsRedirectUrl() {
         // Arrange
         var applicationSettingsRedirectUrl = "https://production.example.com/callback";
         var applicationId = "test-app-id";
@@ -109,8 +110,8 @@ class SecuredOnboardProcessServiceTest {
         var state = "random-state";
 
         var application = createApplicationWithRedirectUrl(applicationId, tenantId, applicationSettingsRedirectUrl);
-        
-        when(onboardStateContainer.push(any(), any(), any(), eq(applicationSettingsRedirectUrl)))
+
+        when(onboardStateContainer.push(any(), any(), any(), eq("")))
                 .thenReturn(state);
         when(authorizationRequestService.getAuthorizationRequestURL(any()))
                 .thenReturn("http://agrirouter.example/authorize?state=" + state);
@@ -121,7 +122,7 @@ class SecuredOnboardProcessServiceTest {
         // Assert
         var captor = ArgumentCaptor.forClass(AuthorizationRequestParameters.class);
         verify(authorizationRequestService).getAuthorizationRequestURL(captor.capture());
-        
+
         var capturedParams = captor.getValue();
         assertThat(capturedParams.getRedirectUri()).isEqualTo(applicationSettingsRedirectUrl);
     }
@@ -133,7 +134,7 @@ class SecuredOnboardProcessServiceTest {
         application.setApplicationType(null);
 
         // Act & Assert
-        assertThrows(BusinessException.class, () -> 
+        assertThrows(BusinessException.class, () ->
                 securedOnboardProcessService.generateAuthorizationUrl(application, "endpoint-id", "http://localhost/callback")
         );
     }
@@ -146,15 +147,15 @@ class SecuredOnboardProcessServiceTest {
         var application = new Application();
         application.setApplicationId(applicationId);
         application.setApplicationType(ApplicationType.FARMING_SOFTWARE);
-        
+
         var tenant = new Tenant();
         tenant.setTenantId(tenantId);
         application.setTenant(tenant);
-        
+
         var settings = new ApplicationSettings();
         settings.setRedirectUrl(redirectUrl);
         application.setApplicationSettings(settings);
-        
+
         return application;
     }
 }

--- a/agrirouter-middleware-business/src/test/java/de/agrirouter/middleware/business/SecuredOnboardProcessServiceTest.java
+++ b/agrirouter-middleware-business/src/test/java/de/agrirouter/middleware/business/SecuredOnboardProcessServiceTest.java
@@ -71,7 +71,7 @@ class SecuredOnboardProcessServiceTest {
     }
 
     @Test
-    void generateAuthorizationUrl_withoutRedirectUrlParameter_shouldNotUseApplicationSettingsRedirectUrl() {
+    void generateAuthorizationUrl_withoutRedirectUrlParameter() {
         // Arrange
         var applicationSettingsRedirectUrl = "https://production.example.com/callback";
         var applicationId = "test-app-id";
@@ -101,7 +101,7 @@ class SecuredOnboardProcessServiceTest {
     }
 
     @Test
-    void generateAuthorizationUrl_withEmptyRedirectUrlParameter_shouldNotUseApplicationSettingsRedirectUrl() {
+    void generateAuthorizationUrl_withEmptyRedirectUrlParameter() {
         // Arrange
         var applicationSettingsRedirectUrl = "https://production.example.com/callback";
         var applicationId = "test-app-id";

--- a/agrirouter-middleware-controller/src/main/java/de/agrirouter/middleware/controller/unsecured/CallbackProcessorController.java
+++ b/agrirouter-middleware-controller/src/main/java/de/agrirouter/middleware/controller/unsecured/CallbackProcessorController.java
@@ -104,8 +104,6 @@ public class CallbackProcessorController implements UnsecuredApiController {
     private RedirectView redirect(OnboardStateContainer.OnboardState onboardState, Application application, OnboardProcessResult result, String errorMessage) {
         if (StringUtils.isNotBlank(onboardState.redirectUrlAfterCallback())) {
             return redirect(result, onboardState.redirectUrlAfterCallback(), errorMessage);
-        } else if (StringUtils.isNotBlank(application.getApplicationSettings().getRedirectUrl())) {
-            return redirect(result, application.getApplicationSettings().getRedirectUrl(), errorMessage);
         } else {
             return redirect(result, Routes.UnsecuredEndpoints.ONBOARD_PROCESS_RESULT, errorMessage);
         }


### PR DESCRIPTION
- Simplified redirect URL logic by removing unnecessary fallback checks in `SecuredOnboardProcessService`.
- Updated test cases to reflect redirect URL changes, ensuring the correct parameters are passed and verified.
- Removed redundant fallback to application settings' redirect URL in `CallbackProcessorController`.

Corrected the assignment of the redirect URL in `SecuredOnboardProcessService` introduced in PR #640 to always use the stored redirect url from application settings for the direct request to ar. The provided redirect url from the method header is instead only used in the appended state to allow ar middleware to redirect back to the originating application. The PR in question introduced a change in which the redirect URL for the request to agrirouter was treated the same as the redirect URL for the system from which the request was originally sent. However, a distinction must be made between these URLs, as there are two separate ones in the full onboarding flow:
`[Telemetry Platform] <--> [AR Middleware] <--> [AR]`