### PR TITLE
chore(pom): bump parent version to 12.3.0

### DIFF
--- a/agrirouter-middleware-api/pom.xml
+++ b/agrirouter-middleware-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>12.2.0</version>
+        <version>12.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-application/pom.xml
+++ b/agrirouter-middleware-application/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>12.2.0</version>
+        <version>12.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-business/pom.xml
+++ b/agrirouter-middleware-business/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>12.2.0</version>
+        <version>12.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-controller/pom.xml
+++ b/agrirouter-middleware-controller/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>12.2.0</version>
+        <version>12.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-domain/pom.xml
+++ b/agrirouter-middleware-domain/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>12.2.0</version>
+        <version>12.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-efdi/pom.xml
+++ b/agrirouter-middleware-efdi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>12.2.0</version>
+        <version>12.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-integration/pom.xml
+++ b/agrirouter-middleware-integration/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>12.2.0</version>
+        <version>12.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-isoxml/pom.xml
+++ b/agrirouter-middleware-isoxml/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>12.2.0</version>
+        <version>12.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/agrirouter-middleware-persistence/pom.xml
+++ b/agrirouter-middleware-persistence/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>agrirouter-middleware</artifactId>
         <groupId>de.agrirouter.middleware</groupId>
-        <version>12.2.0</version>
+        <version>12.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>de.agrirouter.middleware</groupId>
     <artifactId>agrirouter-middleware</artifactId>
-    <version>12.2.0</version>
+    <version>12.3.0</version>
     <packaging>pom</packaging>
 
     <modules>


### PR DESCRIPTION
This pull request updates the parent project version across all modules from `12.2.0` to `12.3.0`. This ensures that all submodules are aligned with the latest parent configuration and dependencies.

Version alignment:

* Updated the version of the parent project in the root `pom.xml` to `12.3.0`.
* Bumped the parent version to `12.3.0` in all module `pom.xml` files:
  - `agrirouter-middleware-api/pom.xml`
  - `agrirouter-middleware-application/pom.xml`
  - `agrirouter-middleware-business/pom.xml`
  - `agrirouter-middleware-controller/pom.xml`
  - `agrirouter-middleware-domain/pom.xml`
  - `agrirouter-middleware-efdi/pom.xml`
  - `agrirouter-middleware-integration/pom.xml`
  - `agrirouter-middleware-isoxml/pom.xml`
  - `agrirouter-middleware-persistence/pom.xml`